### PR TITLE
Finalize MOS6507 instructions implementation

### DIFF
--- a/Atari2600.xcodeproj/project.pbxproj
+++ b/Atari2600.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		954A18732A1AF6FD00EBC582 /* PBXContainerItemProxy */ = {
+		95F564452A42E9D60028A90B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 951E2F7B2A18B11900E6902F /* Project object */;
 			proxyType = 1;
@@ -94,6 +94,7 @@
 			children = (
 				954A18652A1AEE5800EBC582 /* Atari2600 */,
 				953D92A82A1AEB7400EC52AC /* Atari2600Kit */,
+				95F563FD2A42E33E0028A90B /* Frameworks */,
 				951E2F842A18B11900E6902F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -153,6 +154,13 @@
 			path = Debugger;
 			sourceTree = "<group>";
 		};
+		95F563FD2A42E33E0028A90B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -196,7 +204,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				954A18742A1AF6FD00EBC582 /* PBXTargetDependency */,
+				95F564462A42E9D60028A90B /* PBXTargetDependency */,
 			);
 			name = Atari2600;
 			productName = Atari2600;
@@ -298,10 +306,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		954A18742A1AF6FD00EBC582 /* PBXTargetDependency */ = {
+		95F564462A42E9D60028A90B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 953D92A62A1AEB7400EC52AC /* Atari2600Kit */;
-			targetProxy = 954A18732A1AF6FD00EBC582 /* PBXContainerItemProxy */;
+			targetProxy = 95F564452A42E9D60028A90B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -367,7 +375,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -421,7 +429,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;

--- a/Atari2600.xcodeproj/project.pbxproj
+++ b/Atari2600.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		9579CF7B2A3718D200D3EC01 /* MemoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9579CF7A2A3718D200D3EC01 /* MemoryViewController.swift */; };
 		9579CF7D2A37197800D3EC01 /* MemoryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9579CF7C2A37197800D3EC01 /* MemoryView.xib */; };
 		957A12892A3F4517002163C1 /* NSView+ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957A12882A3F4517002163C1 /* NSView+ContentView.swift */; };
+		9597B00D2A46CBB80088822B /* Atari2600KitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597B00C2A46CBB80088822B /* Atari2600KitTests.swift */; };
+		9597B00E2A46CBB80088822B /* Atari2600Kit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 953D92A72A1AEB7400EC52AC /* Atari2600Kit.framework */; };
+		9597B0152A46CBC50088822B /* CPUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597B0142A46CBC50088822B /* CPUTests.swift */; };
 		95A501812A2CFCA400A59616 /* AssemblyView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 95A501802A2CFCA400A59616 /* AssemblyView.xib */; };
 		95AAAC872A221D5500B8C9FD /* DebuggerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AAAC862A221D5500B8C9FD /* DebuggerWindowController.swift */; };
 		95AAAC892A221D5F00B8C9FD /* DebuggerWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 95AAAC882A221D5F00B8C9FD /* DebuggerWindow.xib */; };
@@ -33,6 +36,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		9597B00F2A46CBB80088822B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 951E2F7B2A18B11900E6902F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 953D92A62A1AEB7400EC52AC;
+			remoteInfo = Atari2600Kit;
+		};
 		95F564452A42E9D60028A90B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 951E2F7B2A18B11900E6902F /* Project object */;
@@ -63,6 +73,9 @@
 		9579CF7A2A3718D200D3EC01 /* MemoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewController.swift; sourceTree = "<group>"; };
 		9579CF7C2A37197800D3EC01 /* MemoryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MemoryView.xib; sourceTree = "<group>"; };
 		957A12882A3F4517002163C1 /* NSView+ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+ContentView.swift"; sourceTree = "<group>"; };
+		9597B00A2A46CBB80088822B /* Atari2600KitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Atari2600KitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9597B00C2A46CBB80088822B /* Atari2600KitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atari2600KitTests.swift; sourceTree = "<group>"; };
+		9597B0142A46CBC50088822B /* CPUTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPUTests.swift; sourceTree = "<group>"; };
 		95A501802A2CFCA400A59616 /* AssemblyView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AssemblyView.xib; sourceTree = "<group>"; };
 		95AAAC862A221D5500B8C9FD /* DebuggerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggerWindowController.swift; sourceTree = "<group>"; };
 		95AAAC882A221D5F00B8C9FD /* DebuggerWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DebuggerWindow.xib; sourceTree = "<group>"; };
@@ -86,6 +99,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9597B0072A46CBB80088822B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9597B00E2A46CBB80088822B /* Atari2600Kit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -94,6 +115,7 @@
 			children = (
 				954A18652A1AEE5800EBC582 /* Atari2600 */,
 				953D92A82A1AEB7400EC52AC /* Atari2600Kit */,
+				9597B00B2A46CBB80088822B /* Atari2600KitTests */,
 				95F563FD2A42E33E0028A90B /* Frameworks */,
 				951E2F842A18B11900E6902F /* Products */,
 			);
@@ -104,6 +126,7 @@
 			children = (
 				953D92A72A1AEB7400EC52AC /* Atari2600Kit.framework */,
 				954A18642A1AEE5800EBC582 /* Atari2600.app */,
+				9597B00A2A46CBB80088822B /* Atari2600KitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -130,6 +153,15 @@
 				954A186A2A1AEE5A00EBC582 /* Main.xib */,
 			);
 			path = Atari2600;
+			sourceTree = "<group>";
+		};
+		9597B00B2A46CBB80088822B /* Atari2600KitTests */ = {
+			isa = PBXGroup;
+			children = (
+				9597B00C2A46CBB80088822B /* Atari2600KitTests.swift */,
+				9597B0142A46CBC50088822B /* CPUTests.swift */,
+			);
+			path = Atari2600KitTests;
 			sourceTree = "<group>";
 		};
 		95CE639C2A333365007BD72B /* Debugger */ = {
@@ -211,6 +243,24 @@
 			productReference = 954A18642A1AEE5800EBC582 /* Atari2600.app */;
 			productType = "com.apple.product-type.application";
 		};
+		9597B0092A46CBB80088822B /* Atari2600KitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9597B0132A46CBB80088822B /* Build configuration list for PBXNativeTarget "Atari2600KitTests" */;
+			buildPhases = (
+				9597B0062A46CBB80088822B /* Sources */,
+				9597B0072A46CBB80088822B /* Frameworks */,
+				9597B0082A46CBB80088822B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9597B0102A46CBB80088822B /* PBXTargetDependency */,
+			);
+			name = Atari2600KitTests;
+			productName = Atari2600KitTests;
+			productReference = 9597B00A2A46CBB80088822B /* Atari2600KitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -227,6 +277,9 @@
 					};
 					954A18632A1AEE5800EBC582 = {
 						CreatedOnToolsVersion = 14.3;
+					};
+					9597B0092A46CBB80088822B = {
+						CreatedOnToolsVersion = 14.3.1;
 					};
 				};
 			};
@@ -245,6 +298,7 @@
 			targets = (
 				954A18632A1AEE5800EBC582 /* Atari2600 */,
 				953D92A62A1AEB7400EC52AC /* Atari2600Kit */,
+				9597B0092A46CBB80088822B /* Atari2600KitTests */,
 			);
 		};
 /* End PBXProject section */
@@ -269,6 +323,13 @@
 				950641DD2A39C4B700938403 /* AssemblyAddressCellView.xib in Resources */,
 				954A186C2A1AEE5A00EBC582 /* Main.xib in Resources */,
 				9579CF7D2A37197800D3EC01 /* MemoryView.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9597B0082A46CBB80088822B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -303,9 +364,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9597B0062A46CBB80088822B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9597B0152A46CBC50088822B /* CPUTests.swift in Sources */,
+				9597B00D2A46CBB80088822B /* Atari2600KitTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9597B0102A46CBB80088822B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 953D92A62A1AEB7400EC52AC /* Atari2600Kit */;
+			targetProxy = 9597B00F2A46CBB80088822B /* PBXContainerItemProxy */;
+		};
 		95F564462A42E9D60028A90B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 953D92A62A1AEB7400EC52AC /* Atari2600Kit */;
@@ -559,6 +634,34 @@
 			};
 			name = Release;
 		};
+		9597B0112A46CBB80088822B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.tsyba.Atari2600KitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9597B0122A46CBB80088822B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.tsyba.Atari2600KitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -585,6 +688,15 @@
 			buildConfigurations = (
 				954A186F2A1AEE5A00EBC582 /* Debug */,
 				954A18702A1AEE5A00EBC582 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9597B0132A46CBB80088822B /* Build configuration list for PBXNativeTarget "Atari2600KitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9597B0112A46CBB80088822B /* Debug */,
+				9597B0122A46CBB80088822B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Atari2600.xcodeproj/project.pbxproj
+++ b/Atari2600.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9502E5972A423296007A32DA /* Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9502E5962A423296007A32DA /* Assembly.swift */; };
 		950641DD2A39C4B700938403 /* AssemblyAddressCellView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 950641DC2A39C4B700938403 /* AssemblyAddressCellView.xib */; };
 		950641DF2A39C4E700938403 /* AssemblyAddressCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950641DE2A39C4E700938403 /* AssemblyAddressCellView.swift */; };
 		950641E32A39CDAB00938403 /* BreakpointToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950641E22A39CDAB00938403 /* BreakpointToggle.swift */; };
@@ -42,6 +43,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9502E5962A423296007A32DA /* Assembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assembly.swift; sourceTree = "<group>"; };
 		950641DC2A39C4B700938403 /* AssemblyAddressCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AssemblyAddressCellView.xib; sourceTree = "<group>"; };
 		950641DE2A39C4E700938403 /* AssemblyAddressCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssemblyAddressCellView.swift; sourceTree = "<group>"; };
 		950641E22A39CDAB00938403 /* BreakpointToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreakpointToggle.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				953D92A92A1AEB7400EC52AC /* Atari2600Kit.h */,
 				953D92AE2A1AEB8300EC52AC /* Console.swift */,
 				953D92B02A1AEB9E00EC52AC /* CPU.swift */,
+				9502E5962A423296007A32DA /* Assembly.swift */,
 				9545887D2A1BC907003A45C6 /* Memory.swift */,
 			);
 			path = Atari2600Kit;
@@ -268,6 +271,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9502E5972A423296007A32DA /* Assembly.swift in Sources */,
 				9545887E2A1BC907003A45C6 /* Memory.swift in Sources */,
 				953D92B12A1AEB9E00EC52AC /* CPU.swift in Sources */,
 				953D92AF2A1AEB8300EC52AC /* Console.swift in Sources */,

--- a/Atari2600.xcodeproj/xcshareddata/xcschemes/Atari2600.xcscheme
+++ b/Atari2600.xcodeproj/xcshareddata/xcschemes/Atari2600.xcscheme
@@ -38,7 +38,6 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Atari2600/Debugger/AssemblyViewController.swift
+++ b/Atari2600/Debugger/AssemblyViewController.swift
@@ -9,7 +9,7 @@ import Cocoa
 import Combine
 import Atari2600Kit
 
-typealias Program = [(MOS6507.Address, MOS6507.Instruction)]
+typealias Program = [(MOS6507.Address, MOS6507Assembly.Instruction)]
 typealias Breakpoint = MOS6507.Address
 
 class AssemblyViewController: NSViewController {
@@ -214,16 +214,16 @@ extension String {
 		self = .init(format: "$%04x", address)
 	}
 	
-	init(mnemonic: MOS6507.Mnemonic) {
+	init(mnemonic: MOS6507Assembly.Mnemonic) {
 		self = "\(mnemonic)"
 	}
 	
-	init(addressingMode mode: MOS6507.AddressingMode, operand: Int) {
+	init(addressingMode mode: MOS6507Assembly.AddressingMode, operand: Int) {
 		self = .init(format: mode.formatPattern, operand)
 	}
 }
 
-private extension MOS6507.AddressingMode {
+private extension MOS6507Assembly.AddressingMode {
 	var formatPattern: String {
 		switch self {
 		case .implied:

--- a/Atari2600/Debugger/AssemblyViewController.swift
+++ b/Atari2600/Debugger/AssemblyViewController.swift
@@ -104,7 +104,7 @@ private extension AssemblyViewController {
 			.delay(for: 0.01, scheduler: RunLoop.current)
 			.sink() { [unowned self] in
 				if let data = $0 {
-					self.program = self.console.cpu.decode(data)
+					self.program = MOS6507Assembly.disassemble(data)
 				} else {
 					self.program = nil
 				}

--- a/Atari2600/Debugger/AssemblyViewController.swift
+++ b/Atari2600/Debugger/AssemblyViewController.swift
@@ -277,7 +277,7 @@ private extension NSTableView {
 		let scrollView = self.enclosingScrollView!
 		let rowRect = self.rect(ofRow: row)
 		
-		let viewRect = scrollView.visibleRect
+		let viewRect = scrollView.documentVisibleRect
 		let insets = scrollView.contentInsets
 		
 		return rowRect.minY >= viewRect.minY + insets.top

--- a/Atari2600/Debugger/MemoryViewController.swift
+++ b/Atari2600/Debugger/MemoryViewController.swift
@@ -53,7 +53,7 @@ private extension MemoryViewController {
 				case .reset:
 					self.resetView()
 				case .sync:
-					self.resetMemoryHighlight()
+					self.clearMemoryHighlights()
 				}
 			}.store(in: &self.cancellables)
 		
@@ -90,7 +90,7 @@ private extension MemoryViewController {
 		}
 	}
 	
-	func resetMemoryHighlight() {
+	func clearMemoryHighlights() {
 		for label in self.labels {
 			label.removeHighlights()
 		}

--- a/Atari2600Kit/Assembly.swift
+++ b/Atari2600Kit/Assembly.swift
@@ -1,0 +1,340 @@
+//
+//  Assembly.swift
+//  Atari2600Kit
+//
+//  Created by Serge Tsyba on 20.6.2023.
+//
+
+public class MOS6507Assembly {
+	public enum Mnemonic {
+		// group 1
+		case adc
+		case and
+		case cmp
+		case eor
+		case lda
+		case ora
+		case sbc
+		case sta
+		
+		// group 2
+		case lsr
+		case asl
+		case rol
+		case ror
+		
+		case inc
+		case dec
+		case ldx
+		case stx
+		
+		// group 3
+		case ldy
+		case sty
+		case cpy
+		case cpx
+		case bit
+		case jmp
+		
+		// refister operations
+		case dey
+		case tay
+		case inx
+		case iny
+		case tya
+		case txa
+		case txs
+		case tax
+		case tsx
+		case dex
+		case nop
+		
+		// branch operations
+		case bcc
+		case bcs
+		case beq
+		case bmi
+		case bne
+		case bpl
+		case bvc
+		case bvs
+		
+		// flag operations
+		case clc
+		case sec
+		case cld
+		case sed
+		case cli
+		case sei
+		case clv
+		
+		// push/pull and stack operations
+		case brk
+		case jsr
+		case rti
+		case rts
+		case pha
+		case php
+		case pla
+		case plp
+	}
+	
+	public enum AddressingMode {
+		case implied
+		case immediate
+		case absolute
+		case absoluteX
+		case absoluteY
+		case zeroPage
+		case zeroPageX
+		case zeroPageY
+		case relative
+		case indirectX
+		case indirectY
+	}
+	
+	public struct Instruction {
+		public var mnemonic: Mnemonic
+		public var mode: AddressingMode
+		public var operand: Int
+		
+		var encodedLenght: Int {
+			switch self.mode {
+			case .implied:
+				return 1
+			case .immediate,
+					.relative,
+					.zeroPage, .zeroPageX, .zeroPageY,
+					.indirectX, .indirectY:
+				return 2
+			case .absolute, .absoluteX, .absoluteY:
+				return 3
+			}
+		}
+	}
+}
+
+
+public enum MOS6507AssemblyError: Error {
+	case unknownOpcode(Int)
+}
+
+
+// MARK: -
+// MARK: Disassembling
+extension MOS6507Assembly {
+	public static func disassemble(_ data: Data) -> [(MOS6507.Address, Instruction)] {
+		var program: [(MOS6507.Address, Instruction)] = []
+		var index = data.startIndex
+		
+		while index < data.endIndex {
+			// TODO: return unknown opcodes as data
+			if let instruction = try? Self.decodeInstruction(in: data, at: index) {
+				program.append((index, instruction))
+				index += instruction.encodedLenght
+			} else {
+				index += 1
+			}
+		}
+		return program
+	}
+	
+	static func decodeInstruction(in data: Data, at index: Int) throws -> Instruction {
+		let opcode = Int(data[index])
+		
+		if let mnemonic = Mnemonic(opcode: opcode),
+		   let mode = AddressingMode(opcode: opcode) {
+			let operand = Self.decodeOperand(in: data, at: index + 1, addressing: mode)
+			return Instruction(mnemonic: mnemonic, mode: mode, operand: operand)
+		} else {
+			throw MOS6507AssemblyError.unknownOpcode(index)
+		}
+	}
+	
+	static func decodeOperand(in data: Data, at index: Int, addressing: AddressingMode) -> Int {
+		switch addressing {
+		case .implied:
+			return 0x00
+			
+		case .immediate,
+				.relative,
+				.zeroPage, .zeroPageX, .zeroPageY,
+				.indirectX, .indirectY:
+			return Int(data[index + 1])
+			
+		case .absolute, .absoluteX, .absoluteY:
+			return Int(data[index]) * 0xff + Int(data[index + 1])
+		}
+	}
+}
+
+
+// MARK: -
+extension MOS6507Assembly.Mnemonic {
+	init?(opcode: Int) {
+		switch opcode {
+		case 0x10: self = .bpl
+		case 0x30: self = .bmi
+		case 0x50: self = .bvc
+		case 0x70: self = .bvs
+		case 0x90: self = .bcc
+		case 0xb0: self = .bcs
+		case 0xd0: self = .bne
+		case 0xf0: self = .beq
+			
+		case 0x00: self = .brk
+		case 0x20: self = .jsr
+		case 0x40: self = .rti
+		case 0x60: self = .rts
+			
+		case 0x08: self = .php
+		case 0x28: self = .plp
+		case 0x48: self = .pha
+		case 0x68: self = .pla
+			
+		case 0x18: self = .clc
+		case 0x38: self = .sec
+		case 0x58: self = .cli
+		case 0x78: self = .sei
+		case 0xb8: self = .clv
+		case 0xd8: self = .cld
+		case 0xf8: self = .sed
+			
+		case 0xaa: self = .tax
+		case 0x8a: self = .txa
+		case 0x9a: self = .txs
+		case 0xba: self = .tsx
+		case 0xa8: self = .tay
+		case 0x98: self = .tya
+		case 0xc8: self = .iny
+		case 0xe8: self = .inx
+		case 0x88: self = .dey
+		case 0xca: self = .dex
+			
+		case 0xea: self = .nop
+			
+		default:
+			let group = opcode & 0x3
+			let subcode = opcode >> 5
+			
+			switch group {
+			case 1:
+				switch subcode {
+				case 0: self = .ora
+				case 1: self = .and
+				case 2: self = .eor
+				case 3: self = .adc
+				case 4: self = .sta
+				case 5: self = .lda
+				case 6: self = .cmp
+				case 7: self = .sbc
+				default:
+					return nil
+				}
+			case 2:
+				switch subcode {
+				case 0: self = .asl
+				case 1: self = .rol
+				case 2: self = .lsr
+				case 3: self = .ror
+				case 4: self = .stx
+				case 5: self = .ldx
+				case 6: self = .dec
+				case 7: self = .inc
+				default:
+					return nil
+				}
+			case 0:
+				switch subcode {
+				case 1: self = .bit
+				case 2: self = .jmp
+				case 3: self = .jmp
+				case 4: self = .sty
+				case 5: self = .ldy
+				case 6: self = .cpy
+				case 7: self = .cpx
+				default:
+					return nil
+				}
+			default:
+				return nil
+			}
+		}
+	}
+}
+
+extension MOS6507Assembly.AddressingMode {
+	init?(opcode: Int) {
+		switch opcode {
+			// BPL, BMI, BVC, BVS, BCC, BCS, BNE, BEQ
+		case 0x10, 0x30, 0x50, 0x70, 0x90, 0xb0, 0xd0, 0xf0:
+			self = .relative
+			// BRK, RTI, RTS
+		case 0x00, 0x40, 0x60,
+			// PHP, PLP, PHA, PLA
+			0x08, 0x28, 0x48, 0x68,
+			// CLC, SEC, CLI, SEI, CLV, CLD, SED
+			0x18, 0x38, 0x58, 0x78, 0xb8, 0xd8, 0xf8,
+			// TAX, TXA, TXS, TSX, TAY, TYA, INY, INX, DEY, DEX
+			0xaa, 0x8a, 0x9a, 0xba, 0xa8, 0x98, 0xc8, 0xe8, 0x88, 0xca,
+			// NOP
+			0xea:
+			self = .implied
+			// JSR
+		case 0x20:
+			self = .absolute
+			
+		default:
+			let group = opcode & 0x3
+			let subcode = (opcode >> 2) & 0x7
+			
+			switch group {
+			case 1:
+				switch subcode {
+				case 0: self = .indirectX
+				case 1: self = .zeroPage
+				case 2: self = .immediate
+				case 3: self = .absolute
+				case 4: self = .indirectY
+				case 5: self = .zeroPageX
+				case 6: self = .absoluteY
+				case 7: self = .absoluteX
+				default:
+					return nil
+				}
+			case 2:
+				switch opcode {
+					// STX
+				case 0x96: self = .zeroPageY
+					// LDX
+				case 0xb6: self = .zeroPageY
+					// LDX
+				case 0xbe: self = .absoluteY
+				default:
+					switch subcode {
+					case 0: self = .immediate
+					case 1: self = .zeroPage
+					case 2: self = .implied
+					case 3: self = .absolute
+					case 5: self = .zeroPageX
+					case 7: self = .absoluteX
+					default:
+						return nil
+					}
+				}
+			case 0:
+				switch subcode {
+				case 0: self = .immediate
+				case 1: self = .zeroPage
+				case 3: self = .absolute
+				case 5: self = .zeroPageX
+				case 7: self = .absoluteX
+				default:
+					return nil
+				}
+			default:
+				return nil
+			}
+		}
+	}
+}

--- a/Atari2600Kit/Assembly.swift
+++ b/Atari2600Kit/Assembly.swift
@@ -162,7 +162,7 @@ extension MOS6507Assembly {
 			return Int(data[index])
 			
 		case .absolute, .absoluteX, .absoluteY:
-			return Int(data[index]) * 0xff + Int(data[index + 1])
+			return Int(data[index]) * 0x100 + Int(data[index + 1])
 			
 		case .relative:
 			let offset = Int(data[index])

--- a/Atari2600Kit/Assembly.swift
+++ b/Atari2600Kit/Assembly.swift
@@ -130,7 +130,7 @@ extension MOS6507Assembly {
 		while index < data.endIndex {
 			// TODO: return unknown opcodes as data
 			if let instruction = try? Self.decodeInstruction(in: data, at: index) {
-				program.append((index, instruction))
+				program.append((0xf000 + index, instruction))
 				index += instruction.encodedLenght
 			} else {
 				index += 1
@@ -157,13 +157,16 @@ extension MOS6507Assembly {
 			return 0x00
 			
 		case .immediate,
-				.relative,
 				.zeroPage, .zeroPageX, .zeroPageY,
 				.indirectX, .indirectY:
-			return Int(data[index + 1])
+			return Int(data[index])
 			
 		case .absolute, .absoluteX, .absoluteY:
 			return Int(data[index]) * 0xff + Int(data[index + 1])
+			
+		case .relative:
+			let offset = Int(data[index])
+			return 0xf001 + index + Int(signedWord: offset)
 		}
 	}
 }

--- a/Atari2600Kit/CPU.swift
+++ b/Atari2600Kit/CPU.swift
@@ -664,30 +664,32 @@ private extension MOS6507 {
 			
 		case 0x48:
 			// MARK: PHA
-			return { _ in
-				// TODO: PHA
-				return 0
+			return { [unowned self] _ in
+				self.pushStack(self.accumulator)
+				return 2
 			}
 			
 		case 0x08:
 			// MARK: PHP
-			return { _ in
-				// TODO: PHP
-				return 0
+			return { [unowned self] _ in
+				self.pushStack(self.status.rawValue)
+				return 2
 			}
 			
 		case 0x68:
 			// MARK: PLA
-			return { _ in
-				// TODO: PLA
-				return 0
+			return { [unowned self] _ in
+				self.accumulator = self.pullStack()
+				return 3
 			}
 			
 		case 0x28:
 			// MARK: PLP
-			return { _ in
-				// TODO: PLP
-				return 0
+			return { [unowned self] _ in
+				self.status = Status(
+					rawValue: self.pullStack())!
+				
+				return 3
 			}
 			
 		case 0x2a:
@@ -912,7 +914,7 @@ public extension MOS6507 {
 	typealias Word = Int
 	typealias Address = Int
 	
-	class Status {
+	class Status: RawRepresentable {
 		@Published fileprivate(set) public var carry: Bool
 		@Published fileprivate(set) public var zero: Bool
 		@Published fileprivate(set) public var interruptDisabled: Bool
@@ -929,6 +931,29 @@ public extension MOS6507 {
 			self.break = false
 			self.overflow = false
 			self.negative = false
+		}
+		
+		public required init?(rawValue: Int) {
+			self.carry = rawValue[0]
+			self.zero = rawValue[1]
+			self.interruptDisabled = rawValue[2]
+			self.decimalMode = rawValue[3]
+			self.break = rawValue[4]
+			self.overflow = rawValue[6]
+			self.negative = rawValue[7]
+		}
+		
+		public var rawValue: Int {
+			var value = 0x00
+			value[0] = self.carry
+			value[1] = self.zero
+			value[2] = self.interruptDisabled
+			value[3] = self.decimalMode
+			value[4] = self.break
+			value[6] = self.overflow
+			value[7] = self.negative
+			
+			return value
 		}
 		
 		static var random: Self {

--- a/Atari2600Kit/CPU.swift
+++ b/Atari2600Kit/CPU.swift
@@ -7,15 +7,891 @@
 
 import Combine
 
-public  extension MOS6507 {
-	enum Event {
-		case reset
-		case sync
+public class MOS6507 {
+	private let eventSubject = PassthroughSubject<Event, Never>()
+	private var operations: [Int: Operation] = [:]
+	
+	@Published private(set) public var accumulator: Word
+	@Published private(set) public var x: Word
+	@Published private(set) public var y: Word
+	@Published private(set) public var status: Status
+	
+	@Published private(set) public var stackPointer: Word
+	@Published private(set) public var programCounter: Address
+	
+	var bus: MOS6502Bus!
+	
+	public init() {
+		self.accumulator = .randomWord
+		self.x = .randomWord
+		self.y = .randomWord
+		self.status = .random
+		
+		self.stackPointer = .randomWord
+		self.programCounter = .randomAddress
+		
+		// generate operations look-up
+		for opcode in 0x00...0xff {
+			self.operations[opcode] = self.operation(for: opcode)
+		}
 	}
 	
-	var events: some Publisher<Event, Never> {
-		return self.eventSubject
+	/// Resets this CPU.
+	public func reset() {
+		self.eventSubject.send(.reset)
+		self.status.interruptDisabled = true
+		
+		self.programCounter = Address(
+			self.bus.read(at: 0xfffe),
+			self.bus.read(at: 0xfffd))
 	}
+	
+	/// Performs program instructions until it reaches one at any of the sepcified addresses.
+	public func run(until breakpoints: [MOS6507.Address]) {
+		while !breakpoints.contains(self.programCounter) {
+			self.step()
+		}
+	}
+	
+	/// Performs the next instruction in the program.
+	public func step() {
+		let opcode = self.bus.read(at: self.programCounter)
+		self.eventSubject.send(.sync)
+		
+		if let operation = self.operations[opcode] {
+			let _ = operation()
+		}
+	}
+}
+
+
+// MARK: -
+// MARK: Operation set-up
+private extension MOS6507 {
+	typealias Operation = () -> Int
+	
+	/// Returns operation for the specified opcode.
+	func operation(for opcode: Int) -> Operation? {
+		guard let operation = self.baseOperation(for: opcode),
+			  let offset = self.encodedInstructionLength(withOpcode: opcode) else {
+			return nil
+		}
+		
+		if let dereferenceOperandAddress = self.addressing(for: opcode) {
+			return { [unowned self] in
+				let (operandAddress, cycles1) = dereferenceOperandAddress(self.programCounter + 1)
+				self.programCounter += offset
+				
+				let cycles2 = operation(operandAddress)
+				return cycles1 + cycles2
+			}
+		} else {
+			// instruction with implied operand addressing
+			return { [unowned self] in
+				self.programCounter += offset
+				return operation(self.programCounter)
+			}
+		}
+	}
+	
+	/// Returns part of operation for the specified opcode, which resolves its operand address.
+	func addressing(for opcode: Int) -> ((Address) -> (Address, Int))? {
+		switch opcode {
+		case 0x00, 0x08, 0x0a, 0x18, 0x28, 0x2a, 0x38, 0x40,
+			0x48, 0x4a, 0x58, 0x60, 0x68, 0x6a, 0x78, 0x88,
+			0x8a, 0x98, 0x9a, 0xa8, 0xaa, 0xb8, 0xba, 0xc8,
+			0xca, 0xd8, 0xe8, 0xea, 0xf8:
+			// MARK: Implied
+			return nil
+			
+		case 0x02, 0x09, 0x22, 0x29, 0x42, 0x49, 0x62, 0x69,
+			0x80, 0x82, 0x89, 0xa0, 0xa2, 0xa9, 0xc0, 0xc2,
+			0xc9, 0xe0, 0xe2, 0xe9:
+			// MARK: Immediate
+			return {
+				return ($0, 0)
+			}
+			
+		case 0x0c, 0x0d, 0x0e, 0x20, 0x2c, 0x2d, 0x2e, 0x4c,
+			0x4d, 0x4e, 0x6c, 0x6d, 0x6e, 0x8c, 0x8d, 0x8e,
+			0xac, 0xad, 0xae, 0xcc, 0xcd, 0xce, 0xec, 0xed,
+			0xee:
+			// MARK: Absolute
+			return { [unowned self] in
+				let address = Address(
+					self.bus.read(at: $0),
+					self.bus.read(at: $0 + 1))
+				
+				return (address, 2)
+			}
+			
+		case 0x1c, 0x1d, 0x1e, 0x3c, 0x3d, 0x3e, 0x5c, 0x5d,
+			0x5e, 0x7c, 0x7d, 0x7e, 0x9c, 0x9d, 0x9e, 0xbc,
+			0xbd, 0xdc, 0xdd, 0xde, 0xfc, 0xfd, 0xfe:
+			// MARK: Absolute, X-indexed
+			return { [unowned self] in
+				var address = Address(
+					self.bus.read(at: $0),
+					self.bus.read(at: $0 + 1))
+				
+				let page = address.high
+				address += self.x
+				
+				let cycles = address.high == page ? 2 : 3
+				return (address, cycles)
+			}
+			
+		case 0x19, 0x39, 0x59, 0x79, 0x99, 0xb9, 0xbe, 0xd9,
+			0xf9:
+			// MARK: Absolute, Y-indexed
+			return { [unowned self] in
+				var address = Address(
+					self.bus.read(at: $0),
+					self.bus.read(at: $0 + 1))
+				
+				let page = address.high
+				address += self.y
+				
+				let cycles = address.high == page ? 2 : 3
+				return (address, cycles)
+			}
+			
+		case 0x04, 0x05, 0x06, 0x24, 0x25, 0x26, 0x44, 0x45,
+			0x46, 0x64, 0x65, 0x66, 0x84, 0x85, 0x86, 0xa4,
+			0xa5, 0xa6, 0xc4, 0xc5, 0xc6, 0xe4, 0xe5, 0xe6:
+			// MARK: Zero-page
+			return { [unowned self] in
+				let address = Address(
+					self.bus.read(at: $0),
+					0x00)
+				
+				return (address, 1)
+			}
+			
+		case 0x14, 0x15, 0x16, 0x34, 0x35, 0x36, 0x54, 0x55,
+			0x56, 0x74, 0x75, 0x76, 0x94, 0x95, 0xb4, 0xb5,
+			0xd4, 0xd5, 0xd6, 0xf4, 0xf5, 0xf6:
+			// MARK: Zero-page, X-indexed
+			return { [unowned self] in
+				var address = Address(
+					self.bus.read(at: $0),
+					0x00)
+				
+				address.low += self.x
+				return (address, 2)
+			}
+			
+		case 0x96, 0xb6:
+			// MARK: Zero-page, Y-indexed
+			return { [unowned self] in
+				var address = Address(
+					self.bus.read(at: $0),
+					0x00)
+				
+				address.low += self.y
+				return (address, 2)
+			}
+			
+		case 0x01, 0x21, 0x41, 0x61, 0x81, 0xa1, 0xc1, 0xe1:
+			// MARK: X-indexed, Indirect
+			return { [unowned self] in
+				var address = Address(
+					self.bus.read(at: $0),
+					0x00)
+				
+				address.low += self.x
+				address = Address(
+					self.bus.read(at: address),
+					self.bus.read(at: address + 1))
+				
+				return (address, 4)
+			}
+			
+		case 0x11, 0x31, 0x51, 0x71, 0x91, 0xb1, 0xd1, 0xf1:
+			// MARK: Indirect, Y-indexed
+			return { [unowned self] in
+				var address = Address(
+					self.bus.read(at: $0 + 1),
+					0x00)
+				
+				address = Address(
+					self.bus.read(at: address),
+					self.bus.read(at: address + 1))
+				
+				let page = address.high
+				address += self.y
+				
+				let cycles = address.high == page ? 4 : 5
+				return (address, cycles)
+			}
+			
+		case 0x10, 0x30, 0x50, 0x70, 0x90, 0xb0, 0xd0, 0xf0:
+			// MARK: Relative
+			return {
+				let offset = self.bus.read(at: $0)
+				var address = self.programCounter + 2
+				
+				let page = address.high
+				address += Int(signedWord: offset)
+				
+				let cycles = address.high == page ? 2 : 3
+				return (address, cycles)
+			}
+			
+		default:
+			return nil
+		}
+	}
+	
+	/// Returns part of operation for the specififed opcode, without its operand address resolution.
+	func baseOperation(for opcode: Int) -> ((Address) -> Int)? {
+		switch opcode {
+		case 0x69, 0x65, 0x75, 0x6d, 0x7d, 0x79, 0x61, 0x71:
+			// MARK: ADC
+			return { _ in
+				// TODO: ADC
+				return 0
+			}
+			
+		case 0x29, 0x25, 0x35, 0x2D, 0x3D, 0x39, 0x21, 0x31:
+			// MARK: AND
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.accumulator & operand
+				
+				self.accumulator = result & 0xff
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 1
+			}
+			
+		case 0x0a:
+			// MARK: ASL (accumulator)
+			return { [unowned self] _ in
+				let result = self.accumulator << 1
+				
+				self.accumulator = result & 0xff
+				self.status.carry = result[8]
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0x06, 0x16, 0x0e, 0x1e:
+			// MARK: ASL
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = operand << 1
+				
+				self.bus.write(result & 0xff, at: $0)
+				self.status.carry = result[8]
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 2
+			}
+			
+		case 0x90:
+			// MARK: BCC
+			return { [unowned self] in
+				if self.status.carry == false {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0xb0:
+			// MARK: BCS
+			return { [unowned self] in
+				if self.status.carry {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0xf0:
+			// MARK: BEQ
+			return { [unowned self] in
+				if self.status.zero {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0x24, 0x2c:
+			// MARK: BIT
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.accumulator & operand
+				
+				self.status.overflow = operand[6]
+				self.status.zero = result == 0x00
+				self.status.negative = operand[7]
+				
+				return 1
+			}
+			
+		case 0x30:
+			// MARK: BMI
+			return { [unowned self] in
+				if self.status.negative {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0xd0:
+			// MARK: BNE
+			return { [unowned self] in
+				if self.status.zero == false {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0x10:
+			// MARK: BPL
+			return { [unowned self] in
+				if self.status.negative == false {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0x00:
+			// MARK: BRK
+			return { _ in
+				// TODO: BRK
+				return 0
+			}
+			
+		case 0x50:
+			// MARK: BVC
+			return { [unowned self] in
+				if self.status.overflow == false {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0x70:
+			// MARK: BVS
+			return { [unowned self] in
+				if self.status.overflow {
+					self.programCounter = $0
+				}
+				return 0
+			}
+			
+		case 0x18:
+			// MARK: CLC
+			return { [unowned self] _ in
+				self.status.carry = false
+				return 0
+			}
+			
+		case 0xd8:
+			// MARK: CLD
+			return { [unowned self] _ in
+				self.status.decimalMode = false
+				return 0
+			}
+			
+		case 0x58:
+			// MARK: CLI
+			return { [unowned self] _ in
+				self.status.interruptDisabled = false
+				return 0
+			}
+			
+		case 0xb8:
+			// MARK: CLV
+			return { [unowned self] _ in
+				self.status.overflow = false
+				return 0
+			}
+			
+		case 0xc9, 0xc5, 0xd5, 0xcd, 0xdd, 0xd9, 0xc1, 0xd1:
+			// MARK: CMP
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.accumulator - operand
+				
+				self.status.carry = result >= 0x00
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 1
+			}
+			
+		case 0xe0, 0xe4, 0xec:
+			// MARK: CPX
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.x - operand
+				
+				self.status.carry = result >= 0x00
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 1
+			}
+			
+		case 0xc0, 0xc4, 0xcc:
+			// MARK: CPY
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.y - operand
+				
+				self.status.carry = result >= 0x00
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 1
+			}
+			
+		case 0xc6, 0xd6, 0xce, 0xde:
+			// MARK: DEC
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				var result = operand - 0x01
+				if result < 0x00 {
+					result = 0xff
+				}
+				
+				self.bus.write(result, at: $0)
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 2
+			}
+			
+		case 0xca:
+			// MARK: DEX
+			return { [unowned self] _ in
+				var result = self.x - 0x01
+				if result < 0x00 {
+					result = 0xff
+				}
+				
+				self.x = result
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0x88:
+			// MARK: DEY
+			return { [unowned self] _ in
+				var result = self.y - 0x01
+				if result < 0x00 {
+					result = 0xff
+				}
+				
+				self.y = result
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0x49, 0x45, 0x55, 0x4d, 0x5d, 0x59, 0x41, 0x51:
+			// MARK: EOR
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.accumulator ^ operand
+				
+				self.accumulator = result
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 1
+			}
+			
+		case 0xe6, 0xf6, 0xee, 0xfe:
+			// MARK: INC
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				var result = operand + 0x01
+				if result > 0xff {
+					result = 0x00
+				}
+				
+				self.bus.write(result, at: $0)
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 2
+			}
+			
+		case 0xe8:
+			// MARK: INX
+			return { [unowned self] _ in
+				var result = self.x + 0x01
+				if result > 0xff {
+					result = 0x00
+				}
+				
+				self.x = result
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0xc8:
+			// MARK: INY
+			return { [unowned self] _ in
+				var result = self.y + 0x01
+				if result > 0xff {
+					result = 0x00
+				}
+				
+				self.y = result
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0x20:
+			// MARK: JSR
+			return { _ in
+				// TODO: JSR
+				return 0
+			}
+			
+		case 0xa9, 0xa5, 0xb5, 0xad, 0xbd, 0xb9, 0xa1, 0xb1:
+			// MARK: LDA
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				
+				self.accumulator = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 1
+			}
+			
+		case 0xa2, 0xa6, 0xb6, 0xae, 0xbe:
+			// MARK: LDX
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				
+				self.x = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 1
+			}
+			
+		case 0xa0, 0xa4, 0xb4, 0xac, 0xbc:
+			// MARK: LDY
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				
+				self.y = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 1
+			}
+			
+		case 0x4a:
+			// MARK: LSR (accumulator)
+			return { [unowned self] _ in
+				let carry = self.accumulator[0]
+				let result = self.accumulator >> 1
+				
+				self.accumulator = result
+				self.status.carry = carry
+				self.status.zero = result == 0x00
+				self.status.negative = false
+				
+				return 0
+			}
+			
+		case 0x46, 0x56, 0x4e, 0x5e:
+			// MARK: LSR
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = operand >> 1
+				
+				self.bus.write(result, at: $0)
+				self.status.carry = operand[0]
+				self.status.zero = result == 0x00
+				self.status.negative = false
+				
+				return 1
+			}
+			
+		case 0xea:
+			// MARK: NOP
+			return { _ in
+				return 0
+			}
+			
+		case 0x09, 0x05, 0x15, 0x0d, 0x1d, 0x19, 0x01, 0x11:
+			// MARK: ORA
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				let result = self.accumulator & operand
+				
+				self.accumulator = result
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 1
+			}
+			
+		case 0x48:
+			// MARK: PHA
+			return { _ in
+				// TODO: PHA
+				return 0
+			}
+			
+		case 0x08:
+			// MARK: PHP
+			return { _ in
+				// TODO: PHP
+				return 0
+			}
+			
+		case 0x68:
+			// MARK: PLA
+			return { _ in
+				// TODO: PLA
+				return 0
+			}
+			
+		case 0x28:
+			// MARK: PLP
+			return { _ in
+				// TODO: PLP
+				return 0
+			}
+			
+		case 0x2a:
+			// MARK: ROL (accumulator)
+			return { [unowned self] _ in
+				let operand = self.accumulator
+				var result = operand << 1
+				result[0] = self.status.carry
+				
+				self.accumulator = result & 0xff
+				self.status.carry = operand[7]
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0x26, 0x36, 0x2e, 0x3e:
+			// MARK: ROL
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				var result = operand << 1
+				result[0] = self.status.carry
+				
+				self.bus.write(result & 0xff, at: $0)
+				self.status.carry = operand[7]
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 3
+			}
+			
+		case 0x6a:
+			// MARK: ROR (accumulator)
+			return { [unowned self] _ in
+				let operand = self.accumulator
+				var result = operand >> 1
+				result[7] = self.status.carry
+				
+				self.accumulator = result
+				self.status.carry = operand[0]
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 0
+			}
+			
+		case 0x66, 0x76, 0x6e, 0x7e:
+			// MARK: ROR
+			return { [unowned self] in
+				let operand = self.bus.read(at: $0)
+				var result = operand >> 1
+				result[7] = self.status.carry
+				
+				self.bus.write(result, at: $0)
+				self.status.carry = operand[0]
+				self.status.zero = result == 0x00
+				self.status.negative = result[7]
+				
+				return 3
+			}
+			
+		case 0x40:
+			// MARK: RTI
+			return { _ in
+				// TODO: RTI
+				return 0
+			}
+			
+		case 0x60:
+			// MARK: RTS
+			return { _ in
+				// TODO: RTS
+				return 0
+			}
+			
+		case 0xe9, 0xe5, 0xf5, 0xed, 0xfd, 0xe1, 0xf1:
+			// MARK: SBC
+			return { _ in
+				// TODO: SBC
+				return 0
+			}
+			
+		case 0x38:
+			// MARK: SEC
+			return { [unowned self] _ in
+				self.status.carry = true
+				return 0
+			}
+			
+		case 0xf8:
+			// MARK: SED
+			return { [unowned self] _ in
+				self.status.decimalMode = true
+				return 0
+			}
+			
+		case 0x78:
+			// MARK: SEI
+			return { [unowned self] _ in
+				self.status.interruptDisabled = true
+				return 0
+			}
+			
+		case 0x85, 0x95, 0x8d, 0x9d, 0x99, 0x81, 0x91:
+			// MARK: STA
+			return { [unowned self] in
+				self.bus.write(self.accumulator, at: $0)
+				return 1
+			}
+			
+		case 0x86, 0x96, 0x8e:
+			// MARK: STX
+			return { [unowned self] in
+				self.bus.write(self.x, at: $0)
+				return 1
+			}
+			
+		case 0x84, 0x94, 0x8c:
+			// MARK: STY
+			return { [unowned self] in
+				self.bus.write(self.y, at: $0)
+				return 1
+			}
+			
+		case 0xaa:
+			// MARK: TAX
+			return { [unowned self] _ in
+				let operand = self.accumulator
+				
+				self.x = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 0
+			}
+			
+		case 0xa8:
+			// MARK: TAY
+			return { [unowned self] _ in
+				let operand = self.accumulator
+				
+				self.y = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 0
+			}
+			
+		case 0xba:
+			// MARK: TSX
+			return { [unowned self] _ in
+				let operand = self.stackPointer
+				
+				self.x = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 0
+			}
+			
+		case 0x8a:
+			// MARK: TXA
+			return { [unowned self] _ in
+				let operand = self.x
+				
+				self.accumulator = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 0
+			}
+			
+		case 0x9a:
+			// MARK: TXS
+			return { [unowned self] _ in
+				let operand = self.x
+				
+				self.stackPointer = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 0
+			}
+			
+		case 0x98:
+			// MARK: TYA
+			return { [unowned self] _ in
+				let operand = self.y
+				
+				self.accumulator = operand
+				self.status.zero = operand == 0x00
+				self.status.negative = operand[7]
+				
+				return 0
+			}
+			
+		default:
+			return nil
+		}
+	}
+	
+	/// Returns number of bytes an instruction with the specified opcode takes in assembled program.
+	func encodedInstructionLength(withOpcode opcode: Int) -> Int? {
+		if let mode = MOS6507Assembly.AddressingMode(opcode: opcode) {
+			let instruction = MOS6507Assembly.Instruction(mnemonic: .adc, mode: mode, operand: 0)
+			return instruction.encodedLenght
+		}
+		
+		return nil
+	}
+}
+
+
+// MARK: -
+// MARK: Type definitions
+public extension MOS6507 {
+	typealias Word = Int
+	typealias Address = Int
 	
 	class Status {
 		@Published fileprivate(set) public var carry: Bool
@@ -43,245 +919,18 @@ public  extension MOS6507 {
 	}
 }
 
-public class MOS6507 {
-	@Published private(set) public var accumulator: Word
-	@Published private(set) public var x: Word
-	@Published private(set) public var y: Word
-	@Published private(set) public var status: Status
-	
-	@Published private(set) public var stackPointer: Word
-	@Published private(set) public var programCounter: Address
-	
-	private let eventSubject = PassthroughSubject<Event, Never>()
-	
-	
-	
-	var bus: MOS6502Bus!
-	
-	public init() {
-		self.accumulator = .randomWord
-		self.x = .randomWord
-		self.y = .randomWord
-		self.status = .random
-		
-		self.stackPointer = .randomWord
-		self.programCounter = .randomAddress
+
+// MARK: -
+// MARK: Event management
+public extension MOS6507 {
+	enum Event {
+		case reset
+		case sync
 	}
 	
-	private lazy var operations2: [Mnemonic: (AddressingMode) -> Int] = {[
-		.adc: { [unowned self] mode in
-			self.perform(addressing: mode) { address in
-				self.adc(mode)
-			}
-		},
-		.and: { [unowned self] mode in
-			self.perform(addressing: mode) { address in
-				let operand = self.bus.read(at: address)
-				let result = self.accumulator & operand
-				
-				self.accumulator = result
-				self.status.zero = result == 0x00
-				self.status.negative = result[7]
-				
-				return 1
-			}
-		}
-	]}()
-	
-	private func perform(addressing: AddressingMode, operation: (Address) -> Int) -> Int {
-		return 0
+	var events: some Publisher<Event, Never> {
+		return self.eventSubject
 	}
-	
-	lazy var operations: [Int: () -> Int] = {
-		[
-			// ADC
-			0x69: { [unowned self] in self.and(.immediate) },
-			0x65: { [unowned self] in self.and(.zeroPage) },
-			0x75: { [unowned self] in self.and(.zeroPageX) },
-			0x6d: { [unowned self] in self.and(.absolute) },
-			0x7d: { [unowned self] in self.and(.absoluteX) },
-			0x79: { [unowned self] in self.and(.absoluteY) },
-			0x61: { [unowned self] in self.and(.indirectX) },
-			0x71: { [unowned self] in self.and(.indirectY) },
-			// AND
-			0x29: { [unowned self] in self.and(.immediate) },
-			0x25: { [unowned self] in self.and(.zeroPage) },
-			0x35: { [unowned self] in self.and(.zeroPageX) },
-			0x2d: { [unowned self] in self.and(.absolute) },
-			0x3d: { [unowned self] in self.and(.absoluteX) },
-			0x39: { [unowned self] in self.and(.absoluteY) },
-			0x21: { [unowned self] in self.and(.indirectX) },
-			0x31: { [unowned self] in self.and(.indirectY) },
-			// ASL
-			0x0a: { [unowned self] in self.asl() },
-			0x06: { [unowned self] in self.asl(.zeroPage) },
-			0x16: { [unowned self] in self.asl(.zeroPageX) },
-			0x0e: { [unowned self] in self.asl(.absolute) },
-			0x1e: { [unowned self] in self.asl(.absoluteX) },
-			// BEQ
-			0xf0: { [unowned self] in self.beq() },
-			// BIT
-			0x24: { [unowned self] in self.bit(.zeroPage) },
-			0x2C: { [unowned self] in self.bit(.absolute) },
-			// BMI
-			0x30: { [unowned self] in self.bmi() },
-			// BNE
-			0xd0: { [unowned self] in self.bne() },
-			// BPL
-			0x10: { [unowned self] in self.bpl() },
-			// BVC
-			0x50: { [unowned self] in self.bvc() },
-			// BVS
-			0x70: { [unowned self] in self.bvs() },
-			// CLC
-			0x18: { [unowned self] in self.clc() },
-			// CLD
-			0xd8: { [unowned self] in self.cld() },
-			// CLI
-			0x58: { [unowned self] in self.cli() },
-			// CLV
-			0xb8: { [unowned self] in self.clv() },
-			// CMP
-			0xc9: { [unowned self] in self.cmp(.immediate) },
-			0xc5: { [unowned self] in self.cmp(.zeroPage) },
-			0xd5: { [unowned self] in self.cmp(.zeroPageX) },
-			0xcd: { [unowned self] in self.cmp(.absolute) },
-			0xdd: { [unowned self] in self.cmp(.absoluteX) },
-			0xd9: { [unowned self] in self.cmp(.absoluteY) },
-			0xc1: { [unowned self] in self.cmp(.indirectX) },
-			0xd1: { [unowned self] in self.cmp(.indirectY) },
-			// CPX
-			0xe0: { [unowned self] in self.cpx(.immediate) },
-			0xe4: { [unowned self] in self.cpx(.zeroPage) },
-			0xec: { [unowned self] in self.cpx(.absolute) },
-			// CPY
-			0xc0: { [unowned self] in self.cpy(.immediate) },
-			0xc4: { [unowned self] in self.cpy(.zeroPage) },
-			0xcc: { [unowned self] in self.cpy(.absolute) },
-			// DEC
-			0xc6: { [unowned self] in self.dec(.zeroPage) },
-			0xd6: { [unowned self] in self.dec(.zeroPageX) },
-			0xce: { [unowned self] in self.dec(.absolute) },
-			0xde: { [unowned self] in self.dec(.absoluteX) },
-			// DEX
-			0xca: { [unowned self] in self.dex() },
-			// DEY
-			0x88: { [unowned self] in self.dey() },
-			// EOR
-			0x49: { [unowned self] in self.eor(.immediate) },
-			0x45: { [unowned self] in self.eor(.zeroPage) },
-			0x55: { [unowned self] in self.eor(.zeroPageX) },
-			0x4d: { [unowned self] in self.eor(.absolute) },
-			0x5d: { [unowned self] in self.eor(.absoluteX) },
-			0x59: { [unowned self] in self.eor(.absoluteY) },
-			0x41: { [unowned self] in self.eor(.indirectX) },
-			0x51: { [unowned self] in self.eor(.indirectY) },
-			// INC
-			0xe6: { [unowned self] in self.inc(.zeroPage) },
-			0xf6: { [unowned self] in self.inc(.zeroPageX) },
-			0xee: { [unowned self] in self.inc(.absolute) },
-			0xfe: { [unowned self] in self.inc(.absoluteX) },
-			// INX
-			0xe8: { [unowned self] in self.inx() },
-			// INY
-			0xc8: { [unowned self] in self.iny() },
-			// JSR
-			0x20: { [unowned self] in self.jsr(.absolute) },
-			// LDA
-			0xa9: { [unowned self] in self.lda(.immediate) },
-			0xa5: { [unowned self] in self.lda(.zeroPage) },
-			0xb5: { [unowned self] in self.lda(.zeroPageX) },
-			0xad: { [unowned self] in self.lda(.absolute) },
-			0xbd: { [unowned self] in self.lda(.absoluteX) },
-			0xb9: { [unowned self] in self.lda(.absoluteY) },
-			0xa1: { [unowned self] in self.lda(.indirectX) },
-			0xb1: { [unowned self] in self.lda(.indirectY) },
-			// LDX
-			0xa2: { [unowned self] in self.ldx(.immediate) },
-			0xa6: { [unowned self] in self.ldx(.zeroPage) },
-			0xb6: { [unowned self] in self.ldx(.zeroPageY) },
-			0xae: { [unowned self] in self.ldx(.absolute) },
-			0xbe: { [unowned self] in self.ldx(.absoluteY) },
-			// LDY
-			0xa0: { [unowned self] in self.ldy(.immediate) },
-			0xa4: { [unowned self] in self.ldy(.zeroPage) },
-			0xb4: { [unowned self] in self.ldy(.zeroPageX) },
-			0xac: { [unowned self] in self.ldy(.absolute) },
-			0xbc: { [unowned self] in self.ldy(.absoluteX) },
-			// LSR
-			0x4a: { [unowned self] in self.lsr() },
-			0x46: { [unowned self] in self.lsr(.zeroPage) },
-			0x56: { [unowned self] in self.lsr(.zeroPageX) },
-			0x4e: { [unowned self] in self.lsr(.absolute) },
-			0x5e: { [unowned self] in self.lsr(.absoluteX) },
-			// ORA
-			0x09: { [unowned self] in self.ora(.immediate) },
-			0x05: { [unowned self] in self.ora(.zeroPage) },
-			0x15: { [unowned self] in self.ora(.zeroPageX) },
-			0x0d: { [unowned self] in self.ora(.absolute) },
-			0x1d: { [unowned self] in self.ora(.absoluteX) },
-			0x19: { [unowned self] in self.ora(.absoluteY) },
-			0x01: { [unowned self] in self.ora(.indirectX) },
-			0x11: { [unowned self] in self.ora(.indirectY) },
-			// ROL
-			0x2a: { [unowned self] in self.rol() },
-			0x26: { [unowned self] in self.rol(.zeroPage) },
-			0x36: { [unowned self] in self.rol(.zeroPage) },
-			0x2e: { [unowned self] in self.rol(.absolute) },
-			0x3e: { [unowned self] in self.rol(.absoluteX) },
-			// ROR
-			0x6a: { [unowned self] in self.ror() },
-			0x66: { [unowned self] in self.ror(.zeroPage) },
-			0x76: { [unowned self] in self.ror(.zeroPageX) },
-			0x6e: { [unowned self] in self.ror(.absolute) },
-			0x7e: { [unowned self] in self.ror(.absoluteX) },
-			// RTS
-			0x60: { [unowned self] in self.rts() },
-			// SBC
-			0xe9: { [unowned self] in self.sbc(.immediate) },
-			0xe5: { [unowned self] in self.sbc(.zeroPage) },
-			0xf5: { [unowned self] in self.sbc(.zeroPageX) },
-			0xed: { [unowned self] in self.sbc(.absolute) },
-			0xfd: { [unowned self] in self.sbc(.absoluteX) },
-			0xf9: { [unowned self] in self.sbc(.absoluteY) },
-			0xe1: { [unowned self] in self.sbc(.indirectX) },
-			0xf1: { [unowned self] in self.sbc(.indirectY) },
-			// SEC
-			0x38: { [unowned self] in self.sec() },
-			// SED
-			0xf8: { [unowned self] in self.sed() },
-			// SEI
-			0x78: { [unowned self] in self.sei() },
-			// STA
-			0x85: { [unowned self] in self.sta(.zeroPage) },
-			0x95: { [unowned self] in self.sta(.zeroPageX) },
-			0x8d: { [unowned self] in self.sta(.absolute) },
-			0x9d: { [unowned self] in self.sta(.absoluteX) },
-			0x99: { [unowned self] in self.sta(.absoluteY) },
-			0x81: { [unowned self] in self.sta(.indirectX) },
-			0x91: { [unowned self] in self.sta(.indirectY) },
-			// STX
-			0x86: { [unowned self] in self.stx(.zeroPage) },
-			0x96: { [unowned self] in self.stx(.zeroPageY) },
-			0x8e: { [unowned self] in self.stx(.absolute) },
-			// STY
-			0x84: { [unowned self] in self.sty(.zeroPage) },
-			0x94: { [unowned self] in self.sty(.zeroPageX) },
-			0x8c: { [unowned self] in self.sty(.absolute) },
-			// TAX
-			0xaa: { [unowned self] in self.tax() },
-			// TAY
-			0xa8: { [unowned self] in self.tay() },
-			// TSX
-			0xba: { [unowned self] in self.tsx() },
-			// TXA
-			0x8a: { [unowned self] in self.txa() },
-			// TXS
-			0x9a: { [unowned self] in self.txs() },
-			// TYA
-			0x98: { [unowned self] in self.tya() }
-		]
-	}()
 }
 
 
@@ -290,1508 +939,6 @@ public class MOS6507 {
 protocol MOS6502Bus {
 	func read(at address: MOS6507.Address) -> MOS6507.Word
 	func write(_ value: MOS6507.Word, at address: MOS6507.Address)
-}
-
-private extension MOS6507 {
-	func resolveAddress(using addressing: AddressingMode) -> (Address, Int, Int) {
-		switch addressing {
-		case .immediate:
-			let address = self.programCounter + 1
-			return (address, 2, 1)
-			
-		case .absolute:
-			let address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				self.bus.read(at: self.programCounter + 2))
-			
-			return (address, 3, 3)
-			
-		case .absoluteX:
-			var address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				self.bus.read(at: self.programCounter + 2))
-			
-			let page = address.high
-			address += self.y
-			
-			let cycles = address.high == page ? 3 : 4
-			return (address, 3, cycles)
-			
-		case .absoluteY:
-			var address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				self.bus.read(at: self.programCounter + 2))
-			
-			let page = address.high
-			address += self.y
-			
-			let cycles = address.high == page ? 3 : 4
-			return (address, 3, cycles)
-			
-		case .zeroPage:
-			let address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				0x00)
-			
-			return (address, 2, 2)
-			
-		case .zeroPageX:
-			var address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				0x00)
-			
-			address.low += self.x
-			return (address, 2, 3)
-			
-		case .zeroPageY:
-			var address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				0x00)
-			
-			address.low += self.y
-			return (address, 2, 3)
-			
-		case .indirectX:
-			var address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				0x00)
-			
-			address.low += self.x
-			address = Address(
-				self.bus.read(at: address),
-				self.bus.read(at: address + 1))
-			
-			return (address, 2, 5)
-			
-		case .indirectY:
-			var address = Address(
-				self.bus.read(at: self.programCounter + 1),
-				0x00)
-			
-			address = Address(
-				self.bus.read(at: address),
-				self.bus.read(at: address + 1))
-			
-			let page = address.high
-			address += self.y
-			
-			let cycles = address.high == page ? 5 : 6
-			return (address, 2, cycles)
-			
-		case .relative:
-			var offset = self.bus.read(at: self.programCounter + 1)
-			if offset[7] {
-				offset -= (0xff + 0x01)
-			}
-			
-			var address = self.programCounter + 2
-			
-			let page = address.high
-			address += offset
-			
-			let cycles = address.high == page ? 4 : 3
-			return (address, 2, cycles)
-			
-		default:
-			fatalError("Cannot resolve operand address using \(addressing) addressing mode.")
-		}
-	}
-}
-
-
-// MARK: -
-// MARK: Operations
-private extension MOS6507 {
-	/// Add a value in memory to accumulator with carry.
-	func adc(_ addressing: AddressingMode) -> Int {
-		let (_, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		// TODO: ADC
-		
-		return cycles
-	}
-	
-	/// Conjunct Accumulator with a value in memory.
-	func and(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.accumulator & operand
-		
-		self.accumulator = result & 0xff
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 1
-	}
-	
-	/// Shift bits of Accumulator 1 position to the left.
-	func asl() -> Int {
-		self.programCounter += 1
-		
-		let result = self.accumulator << 1
-		
-		self.accumulator = result & 0xff
-		self.status.carry = result[8]
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return 2
-	}
-	
-	/// Shift bits of value in memory 1 position to the left.
-	func asl(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = operand << 1
-		
-		self.bus.write(result & 0xff, at: address)
-		self.status.carry = result[8]
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 3
-	}
-	
-	/// Branch on zero status set.
-	func beq() -> Int {
-		if self.status.zero {
-			let (address, _, cycles) = self.resolveAddress(using: .relative)
-			
-			self.programCounter = address
-			return cycles
-		} else {
-			self.programCounter += 2
-			return 2
-		}
-	}
-	
-	/// Test Accumulator bits against bits of a value in memory.
-	func bit(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.accumulator & operand
-		
-		self.status.overflow = operand[6]
-		self.status.zero = result == 0x00
-		self.status.negative = operand[7]
-		
-		return cycles + 1
-	}
-	
-	/// Branch on negative status set.
-	func bmi() -> Int {
-		if self.status.negative {
-			let (address, _, cycles) = self.resolveAddress(using: .relative)
-			
-			self.programCounter = address
-			return cycles
-		} else {
-			self.programCounter += 2
-			return 2
-		}
-	}
-	
-	/// Branch on zero status clear.
-	func bne() -> Int {
-		if self.status.zero == false {
-			let (address, _, cycles) = self.resolveAddress(using: .relative)
-			
-			self.programCounter = address
-			return cycles
-		} else {
-			self.programCounter += 2
-			return 2
-		}
-	}
-	
-	/// Branch on negative status clear.
-	func bpl() -> Int {
-		if self.status.negative == false {
-			let (address, _, cycles) = self.resolveAddress(using: .relative)
-			
-			self.programCounter = address
-			return cycles
-		} else {
-			self.programCounter += 2
-			return 2
-		}
-	}
-	
-	/// Branch on zero overflow clear.
-	func bvc() -> Int {
-		if self.status.zero == false {
-			let (address, _, cycles) = self.resolveAddress(using: .relative)
-			
-			self.programCounter = address
-			return cycles
-		} else {
-			self.programCounter += 2
-			return 2
-		}
-	}
-	
-	/// Branch on overflow status set.
-	func bvs() -> Int {
-		if self.status.overflow {
-			let (address, _, cycles) = self.resolveAddress(using: .relative)
-			
-			self.programCounter = address
-			return cycles
-		} else {
-			self.programCounter += 2
-			return 2
-		}
-	}
-	
-	/// Clear carry status.
-	func clc() -> Int {
-		self.programCounter += 1
-		
-		self.status.carry = false
-		return 2
-	}
-	
-	/// Clear decimal mode status.
-	func cld() -> Int {
-		self.programCounter += 1
-		
-		self.status.decimalMode = false
-		return 2
-	}
-	
-	/// Clear intterupt disabled status.
-	func cli() -> Int {
-		self.programCounter += 1
-		
-		self.status.interruptDisabled = false
-		return 2
-	}
-	
-	/// Clear overflow status.
-	func clv() -> Int {
-		self.programCounter += 1
-		
-		self.status.overflow = false
-		return 2
-	}
-	
-	/// Compare Accumulator to a value in memory.
-	func cmp(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.accumulator - operand
-		
-		self.status.carry = result >= 0x00
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 1
-	}
-	
-	/// Compare X register to a value in memory.
-	func cpx(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.x - operand
-		
-		self.status.carry = result >= 0x00
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 1
-	}
-	
-	/// Compare Y register to a value in memory.
-	func cpy(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.y - operand
-		
-		self.status.carry = result >= 0x00
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 1
-	}
-	
-	/// Decrement a value in memory by 1.
-	func dec(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		var result = operand - 0x01
-		if result < 0x00 {
-			result = 0xff
-		}
-		
-		self.bus.write(result, at: address)
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 3
-	}
-	
-	/// Decrement value of X register by 1,
-	func dex() -> Int {
-		self.programCounter += 1
-		
-		var result = self.x - 0x01
-		if result < 0x00 {
-			result = 0xff
-		}
-		
-		self.x = result
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return 2
-	}
-	
-	/// Decrement value of Y register by 1,
-	func dey() -> Int {
-		self.programCounter += 1
-		
-		var result = self.y - 0x01
-		if result < 0x00 {
-			result = 0xff
-		}
-		
-		self.y = result
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return 2
-	}
-	
-	/// Exclusive-disjunct Accumulator with a value in memory.
-	func eor(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.accumulator ^ operand
-		
-		self.accumulator = result
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 1
-	}
-	
-	/// Increment a value in memory by 1.
-	func inc(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		
-		var result = operand + 0x01
-		if result > 0xff {
-			result = 0x00
-		}
-		
-		self.bus.write(result, at: address)
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 3
-	}
-	
-	/// Increment value of X register by 1,
-	func inx() -> Int {
-		self.programCounter += 1
-		
-		var result = self.x + 0x01
-		if result > 0xff {
-			result = 0x00
-		}
-		
-		self.x = result
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return 2
-	}
-	
-	/// Increment value of Y register by 1,
-	func iny() -> Int {
-		self.programCounter += 1
-		
-		var result = self.y + 0x01
-		if result > 0xff {
-			result = 0x00
-		}
-		
-		self.y = result
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return 2
-	}
-	
-	/// Jump to subroutine.
-	func jsr(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		self.pushStack(self.programCounter.high)
-		self.pushStack(self.programCounter.low)
-		self.programCounter = address
-		
-		return cycles + 3
-	}
-	
-	/// Load a value from memory into Accumulator.
-	func lda(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		
-		self.accumulator = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return cycles + 1
-	}
-	
-	/// Load a value from memory into X register.
-	func ldx(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		
-		self.x = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return cycles + 1
-	}
-	
-	/// Load a value from memory into Y register.
-	func ldy(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		
-		self.y = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return cycles + 1
-	}
-	
-	/// Shift bits of Accumulator 1 position to the right.
-	func lsr() -> Int {
-		let (_, bytes, cycles) = self.resolveAddress(using: .implied)
-		self.programCounter += bytes
-		
-		let carry = self.accumulator[0]
-		let result = self.accumulator >> 1
-		
-		self.accumulator = result
-		self.status.carry = carry
-		self.status.zero = result == 0x00
-		self.status.negative = false
-		
-		return cycles
-	}
-	
-	/// Shift bits of value in memory 1 position to the right.
-	func lsr(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = operand >> 1
-		
-		self.bus.write(result, at: address)
-		self.status.carry = operand[0]
-		self.status.zero = result == 0x00
-		self.status.negative = false
-		
-		return cycles + 3
-	}
-	
-	/// Disjunct Accumulator with a value in memory.
-	func ora(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		let result = self.accumulator & operand
-		
-		self.accumulator = result
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 1
-	}
-	
-	/// Rotate bits of Accumulator 1 position to the left.
-	func rol() -> Int {
-		let (_, bytes, cycles) = self.resolveAddress(using: .implied)
-		self.programCounter += bytes
-		
-		let operand = self.accumulator
-		var result = operand << 1
-		result[0] = self.status.carry
-		
-		self.accumulator = result & 0xff
-		self.status.carry = operand[7]
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles
-	}
-	
-	/// Rotate bits of a value in memory 1 position to the left.
-	func rol(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		var result = operand << 1
-		result[0] = self.status.carry
-		
-		self.bus.write(result & 0xff, at: address)
-		self.status.carry = operand[7]
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles + 3
-	}
-	
-	/// Rotate bits of Accumulator 1 position to the right.
-	func ror() -> Int {
-		let (_, bytes, cycles) = self.resolveAddress(using: .implied)
-		self.programCounter += bytes
-		
-		let operand = self.accumulator
-		var result = operand >> 1
-		result[7] = self.status.carry
-		
-		self.accumulator = result
-		self.status.carry = operand[0]
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles
-	}
-	
-	/// Rotate bits of a value in memory 1 position to the right.
-	func ror(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: .implied)
-		self.programCounter += bytes
-		
-		let operand = self.bus.read(at: address)
-		var result = operand >> 1
-		result[7] = self.status.carry
-		
-		self.bus.write(result, at: address)
-		self.status.carry = operand[0]
-		self.status.zero = result == 0x00
-		self.status.negative = result[7]
-		
-		return cycles
-	}
-	
-	/// Return from subroutine.
-	func rts() -> Int {
-		let address = Address(
-			self.pullStack(),
-			self.pullStack())
-		
-		self.programCounter = address + 1
-		return 6
-	}
-	
-	/// Substract a value in memory from accumulator with borrow.
-	func sbc(_ addressing: AddressingMode) -> Int {
-		let (_, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		// TODO: SBC
-		
-		return cycles
-	}
-	
-	/// Set carry status.
-	func sec() -> Int {
-		self.programCounter += 1
-		
-		self.status.carry = false
-		return 2
-	}
-	
-	/// Set decimal mode status.
-	func sed() -> Int {
-		self.programCounter += 1
-		
-		self.status.decimalMode = false
-		return 2
-	}
-	
-	/// Set interrupt disabled status.
-	func sei() -> Int {
-		self.programCounter += 1
-		
-		self.status.interruptDisabled = true
-		return 2
-	}
-	
-	/// Store accumulator in memory.
-	func sta(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		self.bus.write(self.accumulator, at: address)
-		return cycles + 1
-	}
-	
-	/// Store X register in memory.
-	func stx(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		self.bus.write(self.x, at: address)
-		return cycles + 1
-	}
-	
-	/// Store Y register in memory.
-	func sty(_ addressing: AddressingMode) -> Int {
-		let (address, bytes, cycles) = self.resolveAddress(using: addressing)
-		self.programCounter += bytes
-		
-		self.bus.write(self.y, at: address)
-		return cycles + 1
-	}
-	
-	/// Transfer Accumulator into X register.
-	func tax() -> Int {
-		self.programCounter += 1
-		
-		let operand = self.accumulator
-		
-		self.x = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return 2
-	}
-	
-	/// Transfer Accumulator into Y register.
-	func tay() -> Int {
-		self.programCounter += 1
-		
-		let operand = self.accumulator
-		
-		self.y = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return 2
-	}
-	
-	/// Transfer Stack pointer into X register.
-	func tsx() -> Int {
-		self.programCounter += 1
-		
-		let operand = self.stackPointer
-		
-		self.x = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return 2
-	}
-	
-	/// Transfer X register into Accumulator.
-	func txa() -> Int {
-		self.programCounter += 1
-		
-		let operand = self.x
-		
-		self.accumulator = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return 2
-	}
-	
-	/// Transfer X register into Stack pointer.
-	func txs() -> Int {
-		self.programCounter += 1
-		
-		let operand = self.x
-		
-		self.stackPointer = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return 2
-	}
-	
-	/// Transfer Y register into Accumulator.
-	func tya() -> Int {
-		self.programCounter += 1
-		
-		let operand = self.y
-		
-		self.accumulator = operand
-		self.status.zero = operand == 0x00
-		self.status.negative = operand[7]
-		
-		return 2
-	}
-}
-
-public extension MOS6507 {
-	func reset() {
-		self.eventSubject.send(.reset)
-		self.status.interruptDisabled = true
-		
-		self.programCounter = Address(
-			self.bus.read(at: 0xfffe),
-			self.bus.read(at: 0xfffd))
-	}
-	
-	func step() {
-		self.eventSubject.send(.sync)
-		
-		let code = self.bus.read(at: self.programCounter)
-		if let operation = self.operations[code] {
-			let message = String(format: "$%04x \(Mnemonic(opcode: code)!)", self.programCounter)
-			print(message)
-			let _ = operation()
-		} else {
-			let message = String(format: "Illegal opcode %02x at $%04x.", code, self.programCounter)
-			fatalError(message)
-		}
-	}
-	
-	func run(until breakpoints: [MOS6507.Address]) {
-		while !breakpoints.contains(self.programCounter) {
-			self.step()
-		}
-	}
-	
-	private func pushStack(_ data: Word) {
-		let address = 0x0100 + self.stackPointer
-		self.bus.write(data, at: address)
-		self.stackPointer -= 0x01
-	}
-	
-	private func pullStack() -> Word {
-		let address = 0x0100 + self.stackPointer
-		let data = self.bus.read(at: address)
-		self.stackPointer += 0x01
-		
-		return data
-	}
-	//
-	//	private func pushToStack(_ value: Word) {
-	//
-	//	}
-	//
-	//	private func pushToStack(_ address: Address) {
-	//
-	//	}
-	//
-	//	private func pullFromStack() -> Word {
-	//		return 0x00
-	//	}
-	//
-	//	private func read(at adress: Address, using adressing: Addressing) -> Word {
-	//		return 0x00
-	//	}
-	//
-	//	private func operand(adressed adressing: Addressing) -> (Word, Address) {
-	//		return (0x00, 0x0000)
-	//	}
-	//
-	//	private mutating func perform(_ operation: Operation, _ addressing: Addressing) {
-	//		switch operation {
-	//		case .adc:
-	//			// TODO:
-	//			break
-	//
-	//		case .and:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = self.accumulator & operand
-	//
-	//			self.accumulator = result
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .asl:
-	//			let (operand, address) = self.operand(adressed: addressing)
-	//			let result = operand << 1
-	//
-	//			if addressing == .accumulator {
-	//				self.accumulator = result
-	//			} else {
-	//				self.bus.write(result, at: address)
-	//			}
-	//
-	//			self.status.carry = result[8]
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .bcc:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.carry == false {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .bcs:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.carry {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .beq:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.zero {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .bit:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = operand & self.accumulator
-	//
-	//			self.status.overflow = operand[6]
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = operand[7]
-	//
-	//		case .bmi:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.negative {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .bne:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.zero == false {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .bpl:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.negative == false {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .brk:
-	//			self.pushToStack(self.programCounter)
-	//			self.pushToStack(self.status)
-	//			self.status.interrupt = true
-	//
-	//		case .bvc:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.overflow == false {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .bvs:
-	//			let (offset, _) = self.operand(adressed: addressing)
-	//			if self.status.overflow {
-	//				self.programCounter += Address(offset, 0x00)
-	//			}
-	//
-	//		case .clc:
-	//			self.status.carry = false
-	//		case .cld:
-	//			self.status.decimal = false
-	//		case .cli:
-	//			self.status.interrupt = false
-	//		case .clv:
-	//			self.status.overflow = false
-	//
-	//		case .cmp:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = self.accumulator + (~operand + 1)
-	//
-	//			self.status.carry = self.accumulator > operand
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .cpx:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = self.x + (~operand + 1)
-	//
-	//			self.status.carry = self.x >= operand
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .cpy:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = self.y + (~operand + 1)
-	//
-	//			self.status.carry = self.y >= operand
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .dec:
-	//			let (operand, address) = self.operand(adressed: addressing)
-	//			let result = operand + (~0x01 + 1)
-	//
-	//			self.bus.write(result, at: address)
-	//
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .dex:
-	//			let result = self.x + (~0x01 + 1)
-	//
-	//			self.x = result
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .dey:
-	//			let result = self.y + (~0x01 + 1)
-	//
-	//			self.y = result
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .eor:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = self.accumulator ^ operand
-	//
-	//			self.accumulator = result
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .inc:
-	//			let (operand, address) = self.operand(adressed: addressing)
-	//			let result = operand + 1
-	//
-	//			self.bus.write(result, at: address)
-	//
-	//			self.status.zero = result == 0
-	//			self.status.negative = result[7]
-	//
-	//		case .inx:
-	//			let result = self.x + 1
-	//
-	//			self.x = result
-	//			self.status.zero = result == 0
-	//			self.status.negative = result[7]
-	//
-	//		case .iny:
-	//			let result = self.y + 1
-	//
-	//			self.y = result
-	//			self.status.zero = result == 0
-	//			self.status.negative = result[7]
-	//
-	//		case .jmp:
-	//			// TODO: JMP
-	//			break
-	//
-	//		case .jsr:
-	//			// TODO: JSR
-	//			break
-	//
-	//		case .lda:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//
-	//			self.accumulator = operand
-	//			self.status.zero = operand == 0x00
-	//			self.status.negative = operand[7]
-	//
-	//		case .ldx:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//
-	//			self.x = operand
-	//			self.status.zero = operand == 0x00
-	//			self.status.negative = operand[7]
-	//
-	//		case .ldy:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//
-	//			self.y = operand
-	//			self.status.zero = operand == 0x00
-	//			self.status.negative = operand[7]
-	//
-	//		case .lsr:
-	//			let (operand, address) = self.operand(adressed: addressing)
-	//			let result = operand >> 1
-	//
-	//			if addressing == .accumulator {
-	//				self.accumulator = result
-	//			} else {
-	//				self.bus.write(result, at: address)
-	//			}
-	//
-	//			self.status.carry = operand[0]
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = false
-	//
-	//		case .nop:
-	//			// does nothing
-	//			break
-	//
-	//		case .ora:
-	//			let (operand, _) = self.operand(adressed: addressing)
-	//			let result = self.accumulator & operand
-	//
-	//			self.accumulator = result
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .pha:
-	//			self.pushToStack(self.accumulator)
-	//		case .php:
-	//			self.pushToStack(self.status)
-	//		case .pla:
-	//			self.accumulator = self.pullFromStack()
-	//		case .plp:
-	//			self.status = self.pullFromStack()
-	//
-	//		case .rol:
-	//			let (operand, address) = self.operand(adressed: addressing)
-	//			let carry: UInt8 = self.status.carry ? 0x01 : 0x00
-	//			let result = (operand << 1) & carry
-	//
-	//			if addressing == .accumulator {
-	//				self.accumulator = result
-	//			} else {
-	//				self.bus.write(result, at: address)
-	//			}
-	//
-	//			self.status.carry = operand[7]
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .ror:
-	//			let (operand, address) = self.operand(adressed: addressing)
-	//			let carry: UInt8 = self.status.carry ? 0x80 : 0x00
-	//			let result = (operand >> 1) & carry
-	//
-	//			if addressing == .accumulator {
-	//				self.accumulator = result
-	//			} else {
-	//				self.bus.write(result, at: address)
-	//			}
-	//
-	//			self.status.carry = operand[0]
-	//			self.status.zero = result == 0x00
-	//			self.status.negative = result[7]
-	//
-	//		case .rti:
-	//			// TODO: RTI
-	//			break
-	//
-	//		case .rts:
-	//			// TODO: RTS
-	//			break
-	//
-	//		case .sbc:
-	//			// TODO: SBC
-	//			break
-	//
-	//		case .sec:
-	//			self.status.carry = true
-	//		case .sed:
-	//			self.status.decimal = true
-	//		case .sei:
-	//			self.status.interrupt = true
-	//
-	//		case .sta:
-	//			let (_, address) = self.operand(adressed: addressing)
-	//			self.bus.write(self.accumulator, at: address)
-	//
-	//		case .stx:
-	//			let (_, address) = self.operand(adressed: addressing)
-	//			self.bus.write(self.x, at: address)
-	//
-	//		case .sty:
-	//			let (_, address) = self.operand(adressed: addressing)
-	//			self.bus.write(self.y, at: address)
-	//
-	//		case .tax:
-	//			let value = self.accumulator
-	//			self.x = value
-	//
-	//			self.status.zero = value == 0x00
-	//			self.status.negative = value[7]
-	//
-	//		case .tay:
-	//			let value = self.accumulator
-	//			self.y = value
-	//
-	//			self.status.zero = value == 0x00
-	//			self.status.negative = value[7]
-	//
-	//		case .tya:
-	//			let value = self.y
-	//			self.accumulator = value
-	//
-	//			self.status.zero = value == 0x00
-	//			self.status.negative = value[7]
-	//
-	//		case .tsx:
-	//			let value = self.stackPointer.low
-	//			self.x = value
-	//
-	//			self.status.zero = value == 0x00
-	//			self.status.negative = value[7]
-	//
-	//		case .txa:
-	//			let value = self.x
-	//			self.accumulator = value
-	//
-	//			self.status.zero = value == 0x00
-	//			self.status.negative = value[7]
-	//
-	//		case .txs:
-	//			let value = self.x
-	//			self.stackPointer = Address(value, 0x00)
-	//
-	//			self.status.zero = value == 0x00
-	//			self.status.negative = value[7]
-	//		}
-	//	}
-	//
-	struct Instruction {
-		public var mnemonic: Mnemonic
-		public var mode: AddressingMode
-		public var operand: Int
-		
-		var encodedLenght: Int {
-			switch self.mode {
-			case .implied:
-				return 1
-			case .immediate,
-					.relative,
-					.zeroPage, .zeroPageX, .zeroPageY,
-					.indirectX, .indirectY:
-				return 2
-			case .absolute, .absoluteX, .absoluteY:
-				return 3
-			}
-		}
-	}
-	
-	enum DecodeError: Error {
-		case unknownOpcode(Int)
-	}
-	
-	func decodeInstruction(at address: Address) throws -> Instruction {
-		let opcode = self.bus.read(at: address)
-		
-		if let mnemonic = Mnemonic(opcode: opcode),
-		   let mode = AddressingMode(opcode: opcode) {
-			let operand = self.readOperand(at: address, addressed: mode)
-			return Instruction(mnemonic: mnemonic, mode: mode, operand: operand)
-		} else {
-			throw DecodeError.unknownOpcode(opcode)
-		}
-	}
-	
-	func decode(_ data: Data) -> [(Address, Instruction)] {
-		var instructions: [(Address, Instruction)] = []
-		var address = 0xf000
-		
-		while address < 0xffff {
-			let opcode = self.bus.read(at: address)
-			
-			guard let mnemonic = Mnemonic(opcode: opcode),
-				  let mode = AddressingMode(opcode: opcode) else {
-				address += 1
-				continue
-			}
-			
-			let operand = self.readOperand(at: address, addressed: mode)
-			let instruction = Instruction(mnemonic: mnemonic, mode: mode, operand: operand)
-			instructions.append((address, instruction))
-			
-			address += instruction.encodedLenght
-		}
-		
-		return instructions
-	}
-	
-	func readOperand(at address: Address, addressed mode: AddressingMode) -> Int {
-		switch mode {
-		case .implied:
-			return 0x00
-			
-		case .immediate,
-				.relative,
-				.zeroPage, .zeroPageX, .zeroPageY,
-				.indirectX, .indirectY:
-			return self.bus.read(at: address + 1)
-			
-		case .absolute, .absoluteX, .absoluteY:
-			return Int(
-				self.bus.read(at: address + 1),
-				self.bus.read(at: address + 2))
-		}
-	}
-	
-	func decode(data: Data) {
-		var index = data.startIndex
-		
-		while index < data.endIndex {
-			let opcode = data[index]
-			guard let operation = Mnemonic(opcode: MOS6507.Word(opcode)),
-				  let addressing = AddressingMode(opcode: MOS6507.Word(opcode)) else {
-				
-				print(String(format: "%04x\t%02x\t\t?", index, opcode))
-				index += 1
-				continue
-			}
-			
-			switch addressing {
-			case .implied:
-				print(String(format: "%04x\t%02x\t\t\(operation)", index, opcode))
-				index += 1
-			case .immediate:
-				let operand = data[index + 1]
-				print(String(format: "%04x\t%02x %02x\t\(operation) #$%02x", index, opcode, operand, operand))
-				index += 2
-				
-			case .relative:
-				let operand = data[index + 1]
-				var address = UInt16(index + 2)
-				if operand > 0x7f {
-					address -= UInt16(~operand + 1) & 0x7f
-				} else {
-					address += UInt16(operand)
-				}
-				
-				print(String(format: "%04x\t%02x %02x\t\(operation) $%04x", index, opcode, operand, address))
-				index += 2
-				
-			case .zeroPage:
-				let operand = data[index + 1]
-				print(String(format: "%04x\t%02x %02x\t\(operation) $%02x", index, opcode, operand, operand))
-				index += 2
-			case .zeroPageX:
-				let operand = data[index + 1]
-				print(String(format: "%04x\t%02x %02x\t\(operation) $%02x,X", index, opcode, operand, operand))
-				index += 2
-			case .zeroPageY:
-				let operand = data[index + 1]
-				print(String(format: "%04x\t%02x %02x\t\(operation) $%02x,Y", index, opcode, operand, operand))
-				index += 2
-				
-			case .absolute:
-				let operand = Address(data[index + 1], data[index + 2])
-				print(String(format: "%04x\t%02x %04x\t\(operation) $%04x", index, opcode, operand, operand))
-				index += 3
-			case .absoluteX:
-				let operand = Address(data[index + 1], data[index + 2])
-				print(String(format: "%04x\t%02x %04x\t\(operation) $%04x,X", index, opcode, operand, operand))
-				index += 3
-			case .absoluteY:
-				let operand = Address(data[index + 1], data[index + 2])
-				print(String(format: "%04x\t%02x %04x\t\(operation) $%04x,Y", index, opcode, operand, operand))
-				index += 3
-				
-			case .indirectX:
-				let operand = data[index + 1]
-				print(String(format: "%04x\t%02x %02x\t\(operation) ($%02x,X)", index, opcode, operand, operand))
-				index += 2
-			case .indirectY:
-				let operand = data[index + 1]
-				print(String(format: "%04x\t%02x %02x\t\(operation) ($%02x),Y", index, opcode, operand, operand))
-				index += 2
-			}
-		}
-	}
-}
-
-
-public extension MOS6507 {
-	typealias Word = Int
-	typealias Address = Int
-//	typealias Status = UInt8
-}
-
-private extension Int {
-	subscript(bit: Int) -> Bool {
-		get {
-			let mask = 0x01 << bit
-			return self & mask == mask
-		}
-		set {
-			let mask = 0x01 << bit
-			if newValue {
-				self |= mask
-			} else {
-				self &= ~mask
-			}
-		}
-	}
-}
-
-//public extension MOS6507.Status {
-//	subscript(bit: Int) -> Bool {
-//		get {
-//			let mask: Self = 0x01 << bit
-//			return self & mask == mask
-//		}
-//		set {
-//			let mask: Self = 0x01 << bit
-//			if newValue {
-//				self |= mask
-//			} else {
-//				self &= ~mask
-//			}
-//		}
-//	}
-//}
-//
-//public extension MOS6507.Status {
-//	var carry: Bool {
-//		get { return self[0] }
-//		set { self[0] = newValue }
-//	}
-//
-//	var zero: Bool {
-//		get { return self[1] }
-//		set { self[1] = newValue }
-//	}
-//
-//	var interruptDisabled: Bool {
-//		get { return self[2] }
-//		set { self[2] = newValue }
-//	}
-//
-//	var decimal: Bool {
-//		get { return self[3] }
-//		set { self[3] = newValue }
-//	}
-//
-//	var `break`: Bool {
-//		get { return self[4] }
-//		set { self[4] = newValue }
-//	}
-//
-//	var overflow: Bool {
-//		get { return self[6] }
-//		set { self[6] = newValue }
-//	}
-//
-//	var negative: Bool {
-//		get { return self[7] }
-//		set { self[7] = newValue }
-//	}
-//}
-
-extension MOS6507.Word {
-	var isNegative: Bool {
-		return self & 0x80 == 0x80
-	}
-}
-
-public extension MOS6507 {
-	enum Mnemonic {
-		// group 1
-		case adc
-		case and
-		case cmp
-		case eor
-		case lda
-		case ora
-		case sbc
-		case sta
-		
-		// group 2
-		case lsr
-		case asl
-		case rol
-		case ror
-		
-		case inc
-		case dec
-		case ldx
-		case stx
-		
-		// group 3
-		case ldy
-		case sty
-		case cpy
-		case cpx
-		case bit
-		case jmp
-		
-		// refister operations
-		case dey
-		case tay
-		case inx
-		case iny
-		case tya
-		case txa
-		case txs
-		case tax
-		case tsx
-		case dex
-		case nop
-		
-		// branch operations
-		case bcc
-		case bcs
-		case beq
-		case bmi
-		case bne
-		case bpl
-		case bvc
-		case bvs
-		
-		// flag operations
-		case clc
-		case sec
-		case cld
-		case sed
-		case cli
-		case sei
-		case clv
-		
-		// push/pull and stack operations
-		case brk
-		case jsr
-		case rti
-		case rts
-		case pha
-		case php
-		case pla
-		case plp
-	}
-	
-	enum AddressingMode {
-		case implied
-		case immediate
-		case absolute
-		case absoluteX
-		case absoluteY
-		case zeroPage
-		case zeroPageX
-		case zeroPageY
-		case relative
-		case indirectX
-		case indirectY
-	}
 }
 
 
@@ -1827,178 +974,6 @@ private extension MOS6507.Address {
 
 
 // MARK: -
-// MARK: Operation decoding
-public extension MOS6507.Mnemonic {
-	init?(opcode: MOS6507.Word) {
-		switch opcode {
-		case 0x10: self = .bpl
-		case 0x30: self = .bmi
-		case 0x50: self = .bvc
-		case 0x70: self = .bvs
-		case 0x90: self = .bcc
-		case 0xb0: self = .bcs
-		case 0xd0: self = .bne
-		case 0xf0: self = .beq
-			
-		case 0x00: self = .brk
-		case 0x20: self = .jsr
-		case 0x40: self = .rti
-		case 0x60: self = .rts
-			
-		case 0x08: self = .php
-		case 0x28: self = .plp
-		case 0x48: self = .pha
-		case 0x68: self = .pla
-			
-		case 0x18: self = .clc
-		case 0x38: self = .sec
-		case 0x58: self = .cli
-		case 0x78: self = .sei
-		case 0xb8: self = .clv
-		case 0xd8: self = .cld
-		case 0xf8: self = .sed
-			
-		case 0xaa: self = .tax
-		case 0x8a: self = .txa
-		case 0x9a: self = .txs
-		case 0xba: self = .tsx
-		case 0xa8: self = .tay
-		case 0x98: self = .tya
-		case 0xc8: self = .iny
-		case 0xe8: self = .inx
-		case 0x88: self = .dey
-		case 0xca: self = .dex
-			
-		case 0xea: self = .nop
-			
-		default:
-			let group = opcode & 0x3
-			let subcode = opcode >> 5
-			
-			switch group {
-			case 1:
-				switch subcode {
-				case 0: self = .ora
-				case 1: self = .and
-				case 2: self = .eor
-				case 3: self = .adc
-				case 4: self = .sta
-				case 5: self = .lda
-				case 6: self = .cmp
-				case 7: self = .sbc
-				default:
-					return nil
-				}
-			case 2:
-				switch subcode {
-				case 0: self = .asl
-				case 1: self = .rol
-				case 2: self = .lsr
-				case 3: self = .ror
-				case 4: self = .stx
-				case 5: self = .ldx
-				case 6: self = .dec
-				case 7: self = .inc
-				default:
-					return nil
-				}
-			case 0:
-				switch subcode {
-				case 1: self = .bit
-				case 2: self = .jmp
-				case 3: self = .jmp
-				case 4: self = .sty
-				case 5: self = .ldy
-				case 6: self = .cpy
-				case 7: self = .cpx
-				default:
-					return nil
-				}
-			default:
-				return nil
-			}
-		}
-	}
-}
-
-public extension MOS6507.AddressingMode {
-	init?(opcode: MOS6507.Word) {
-		switch opcode {
-			// BPL, BMI, BVC, BVS, BCC, BCS, BNE, BEQ
-		case 0x10, 0x30, 0x50, 0x70, 0x90, 0xb0, 0xd0, 0xf0:
-			self = .relative
-			// BRK, RTI, RTS
-		case 0x00, 0x40, 0x60,
-			// PHP, PLP, PHA, PLA
-			0x08, 0x28, 0x48, 0x68,
-			// CLC, SEC, CLI, SEI, CLV, CLD, SED
-			0x18, 0x38, 0x58, 0x78, 0xb8, 0xd8, 0xf8,
-			// TAX, TXA, TXS, TSX, TAY, TYA, INY, INX, DEY, DEX
-			0xaa, 0x8a, 0x9a, 0xba, 0xa8, 0x98, 0xc8, 0xe8, 0x88, 0xca,
-			// NOP
-			0xea:
-			self = .implied
-			// JSR
-		case 0x20:
-			self = .absolute
-			
-		default:
-			let group = opcode & 0x3
-			let subcode = (opcode >> 2) & 0x7
-			
-			switch group {
-			case 1:
-				switch subcode {
-				case 0: self = .indirectX
-				case 1: self = .zeroPage
-				case 2: self = .immediate
-				case 3: self = .absolute
-				case 4: self = .indirectY
-				case 5: self = .zeroPageX
-				case 6: self = .absoluteY
-				case 7: self = .absoluteX
-				default:
-					return nil
-				}
-			case 2:
-				switch opcode {
-					// STX
-				case 0x96: self = .zeroPageY
-					// LDX
-				case 0xb6: self = .zeroPageY
-					// LDX
-				case 0xbe: self = .absoluteY
-				default:
-					switch subcode {
-					case 0: self = .immediate
-					case 1: self = .zeroPage
-					case 2: self = .implied
-					case 3: self = .absolute
-					case 5: self = .zeroPageX
-					case 7: self = .absoluteX
-					default:
-						return nil
-					}
-				}
-			case 0:
-				switch subcode {
-				case 0: self = .immediate
-				case 1: self = .zeroPage
-				case 3: self = .absolute
-				case 5: self = .zeroPageX
-				case 7: self = .absoluteX
-				default:
-					return nil
-				}
-			default:
-				return nil
-			}
-		}
-	}
-}
-
-
-// MARK: -
 // MARK: Convenience functionality
 extension Int {
 	static var randomWord: Self {
@@ -2007,5 +982,26 @@ extension Int {
 	
 	static var randomAddress: Self {
 		return Self.random(in: 0x0000...0xffff)
+	}
+	
+	init(signedWord value: Int) {
+		self = value > 0x7f
+		? value - 0x100
+		: value
+	}
+	
+	subscript(bit: Int) -> Bool {
+		get {
+			let mask = 0x01 << bit
+			return self & mask == mask
+		}
+		set {
+			let mask = 0x01 << bit
+			if newValue {
+				self |= mask
+			} else {
+				self &= ~mask
+			}
+		}
 	}
 }

--- a/Atari2600Kit/CPU.swift
+++ b/Atari2600Kit/CPU.swift
@@ -877,6 +877,7 @@ private extension MOS6507 {
 	
 	/// Returns number of bytes an instruction with the specified opcode takes in assembled program.
 	func encodedInstructionLength(withOpcode opcode: Int) -> Int? {
+		// TODO: replace encoded instruction length resolution with a static dictionary
 		if let mode = MOS6507Assembly.AddressingMode(opcode: opcode) {
 			let instruction = MOS6507Assembly.Instruction(mnemonic: .adc, mode: mode, operand: 0)
 			return instruction.encodedLenght

--- a/Atari2600KitTests/Atari2600KitTests.swift
+++ b/Atari2600KitTests/Atari2600KitTests.swift
@@ -1,0 +1,35 @@
+//
+//  Atari2600KitTests.swift
+//  Atari2600KitTests
+//
+//  Created by Serge Tsyba on 24.6.2023.
+//
+
+import XCTest
+
+final class Atari2600KitTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Atari2600KitTests/CPUTests.swift
+++ b/Atari2600KitTests/CPUTests.swift
@@ -1,0 +1,94 @@
+//
+//  CPUTests.swift
+//  Atari2600KitTests
+//
+//  Created by Serge Tsyba on 24.6.2023.
+//
+
+import XCTest
+@testable import Atari2600Kit
+
+class MOS6507Tests: XCTestCase {
+	// MARK: ADC
+	class ADCWithoutCarryTests: XCTestCase {
+		func testAddsToAccumulator() {
+			let cpu = MOS6507()
+				.adc(accumulator: 0x16, value: 0x3f)
+			
+			XCTAssertEqual(cpu.accumulator, 0x55)
+			XCTAssertEqual(cpu.status.carry, false)
+			XCTAssertEqual(cpu.status.zero, false)
+			XCTAssertEqual(cpu.status.overflow, false)
+			XCTAssertEqual(cpu.status.negative, false)
+		}
+		
+		func testSetsCarryStatusWhenResultOverflows() {
+			let cpu = MOS6507()
+				.adc(accumulator: 0xb9, value: 0x7e)
+			
+			XCTAssertEqual(cpu.accumulator, 0x37)
+			XCTAssertEqual(cpu.status.carry, true)
+		}
+		
+		func testSetsZeroStatusWhenResultZero() {
+			let cpu = MOS6507()
+				.adc(accumulator: 0xb9, value: 0x47)
+			
+			XCTAssertEqual(cpu.accumulator, 0x00)
+			XCTAssertEqual(cpu.status.zero, true)
+		}
+		
+		func testSetsOverflowStatusWhenSignedResultOverflows() {
+			let cpu = MOS6507()
+				.adc(accumulator: 0x50, value: 0x50)
+			
+			XCTAssertEqual(cpu.accumulator, 0xa0)
+			XCTAssertEqual(cpu.status.overflow, true)
+		}
+		
+		func testSetsNegativeStatusWhenSignedResultNegative() {
+			let cpu = MOS6507()
+				.adc(accumulator: 0x4a, value: 0x3f)
+			
+			XCTAssertEqual(cpu.accumulator, 0x89)
+			XCTAssertEqual(cpu.status.negative, true)
+		}
+	}
+	
+	
+}
+
+
+// MARK: -
+// MARK: Convenience functionality
+private extension MOS6507 {
+	func run(program: [Int]) {
+		self.bus = program
+		self.reset()
+		
+		for _ in program {
+			self.step()
+		}
+	}
+	
+	func adc(accumulator: Int, value: Int) -> MOS6507 {
+		self.run(program: [
+			0xd8,				// cld
+			0xa9, accumulator,	// lda $#4a
+			0x69, value			// adc $#3f
+		])
+		return self
+	}
+}
+
+extension Array: MOS6502Bus where Element == Int {
+	public func read(at address: Atari2600Kit.MOS6507.Address) -> Atari2600Kit.MOS6507.Word {
+		return self.indices.contains(address)
+		? self[address]
+		: 0x00
+	}
+	
+	public func write(_ value: Atari2600Kit.MOS6507.Word, at address: Atari2600Kit.MOS6507.Address) {
+		// does nothing
+	}
+}


### PR DESCRIPTION
This update adds support for the remainder of previously unimplemented CPU instructions. Additionally, it refactors program disassembly functionality into a separate type.