### PR TITLE
Set rendering to a constant frame-rate.

### DIFF
--- a/RayRacer/Base.lproj/Main.xib
+++ b/RayRacer/Base.lproj/Main.xib
@@ -155,10 +155,10 @@
                                     <action selector="didSelectGameResumeMenuItem:" target="-1" id="d3B-ZI-7Yf"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Reset" alternate="YES" keyEquivalent="r" identifier="ResetMenuItem" id="S33-bq-fEN">
+                            <menuItem title="Console Reset" alternate="YES" keyEquivalent="r" identifier="ConsoleResetMenuItem" id="S33-bq-fEN">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
-                                    <action selector="didSelectResetMenuItem:" target="-1" id="kB4-qh-B8p"/>
+                                    <action selector="didSelectConsoleResetMenuItem:" target="-1" id="6li-yN-oih"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/RayRacer/Debugger/DebuggerWindow.xib
+++ b/RayRacer/Debugger/DebuggerWindow.xib
@@ -59,30 +59,30 @@
             <toolbar key="toolbar" implicitIdentifier="1042316F-9260-480B-AC8B-55DC96BF8C6E" autosavesConfiguration="NO" showsBaselineSeparator="NO" displayMode="iconAndLabel" sizeMode="regular" id="LSb-J4-Z97">
                 <allowedToolbarItems>
                     <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="t5g-MI-3EV"/>
-                    <toolbarItem implicitItemIdentifier="AC7480E9-C555-43FF-932E-01D195016076" explicitItemIdentifier="ResumeToolbarItem" label="Resume" paletteLabel="Resume" tag="-1" image="play" catalog="system" bordered="YES" sizingBehavior="auto" id="hES-oj-yEd">
+                    <toolbarItem implicitItemIdentifier="AC7480E9-C555-43FF-932E-01D195016076" explicitItemIdentifier="GameResumeToolbarItem" label="Resume" paletteLabel="Resume" tag="-1" image="play" catalog="system" bordered="YES" sizingBehavior="auto" id="hES-oj-yEd">
                         <connections>
-                            <action selector="didSelectGameResumeMenuItem:" target="-1" id="RPq-3O-VcL"/>
+                            <action selector="didSelectGameResumeMenuItem:" target="-1" id="DdN-ku-fIO"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="47624D7F-560E-48A5-8388-78924C654B1A" explicitItemIdentifier="StepInstructionToolbarItem" label="Step instruction" paletteLabel="Step instruction" tag="-1" image="forward.frame" catalog="system" bordered="YES" sizingBehavior="auto" id="a8G-Mj-SRq">
+                    <toolbarItem implicitItemIdentifier="47624D7F-560E-48A5-8388-78924C654B1A" explicitItemIdentifier="StepCPUInstructionToolbarItem" label="Step instruction" paletteLabel="Step instruction" tag="-1" image="forward.frame" catalog="system" bordered="YES" sizingBehavior="auto" id="a8G-Mj-SRq">
                         <connections>
-                            <action selector="didSelectStepInstructionMenuItem:" target="-1" id="RNm-RY-qyU"/>
+                            <action selector="didSelectStepCPUInstructionMenuItem:" target="-1" id="R1C-iK-Axt"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="E132270C-48D9-4F46-BC1B-C4F72045B454" explicitItemIdentifier="StepScanLineToolbarItem" label="Step scan line" paletteLabel="Step scan line" tag="-1" image="forward.frame" catalog="system" bordered="YES" sizingBehavior="auto" id="Aa8-QI-KVy">
+                    <toolbarItem implicitItemIdentifier="E132270C-48D9-4F46-BC1B-C4F72045B454" explicitItemIdentifier="StepTVScanLineToolbarItem" label="Step scan line" paletteLabel="Step scan line" tag="-1" image="forward.frame" catalog="system" bordered="YES" sizingBehavior="auto" id="Aa8-QI-KVy">
                         <connections>
-                            <action selector="didSelectStepScanLineMenuItem:" target="-1" id="9je-gD-IFc"/>
+                            <action selector="didSelectStepTVScanLineMenuItem:" target="-1" id="MLX-yx-rqX"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="295F8941-6FBB-4E40-85F9-5F67E52DCDB0" explicitItemIdentifier="StepFieldToolbarItem" label="Step field" paletteLabel="Step field" tag="-1" image="forward.frame" catalog="system" bordered="YES" sizingBehavior="auto" id="T0T-jK-rXU">
+                    <toolbarItem implicitItemIdentifier="295F8941-6FBB-4E40-85F9-5F67E52DCDB0" explicitItemIdentifier="StepTVFieldToolbarItem" label="Step field" paletteLabel="Step field" tag="-1" image="forward.frame" catalog="system" bordered="YES" sizingBehavior="auto" id="T0T-jK-rXU">
                         <connections>
-                            <action selector="didSelectStepFieldMenuItem:" target="-1" id="GWW-xH-Mc2"/>
+                            <action selector="didSelectStepTVFieldMenuItem:" target="-1" id="IrW-1g-kmx"/>
                         </connections>
                     </toolbarItem>
                     <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="3dM-6U-NvA"/>
                     <toolbarItem implicitItemIdentifier="77641F15-AA2A-494F-B390-F1951124CACE" explicitItemIdentifier="ResetToolbarItem" label="Reset" paletteLabel="Reset" tag="-1" image="restart.circle" catalog="system" bordered="YES" sizingBehavior="auto" id="w7k-DC-Qam">
                         <connections>
-                            <action selector="didSelectResetMenuItem:" target="-1" id="a83-3p-KKT"/>
+                            <action selector="didSelectConsoleResetMenuItem:" target="-1" id="m9S-en-FUv"/>
                         </connections>
                     </toolbarItem>
                 </allowedToolbarItems>

--- a/RayRacer/Debugger/MultiStepperViewController.swift
+++ b/RayRacer/Debugger/MultiStepperViewController.swift
@@ -12,7 +12,7 @@ class MultiStepperViewController: NSTitlebarAccessoryViewController {
 	@IBOutlet private var textField: NSTextField!
 	
 	private let defaults: UserDefaults = .standard
-	var handler: ((Action) -> Void)? = nil
+	var handler: ((Step, Int) -> Void)? = nil
 	
 	convenience init() {
 		self.init(nibName: "MultiStepperView", bundle: .main)
@@ -30,11 +30,6 @@ extension MultiStepperViewController {
 		case instructions = 0
 		case scanLines = 1
 		case fields = 2
-	}
-	
-	enum Action {
-		case step(Step, Int)
-		case done
 	}
 }
 
@@ -54,13 +49,6 @@ extension MultiStepperViewController {
 		super.viewDidAppear()
 		_ = self.becomeFirstResponder()
 	}
-	
-	override func viewWillDisappear() {
-		super.viewWillDisappear()
-		
-		self.defaults.debugStep = Step(rawValue: self.popUpButton.indexOfSelectedItem)!
-		self.defaults.debugStepCount = self.textField.integerValue
-	}
 }
 
 
@@ -68,13 +56,21 @@ extension MultiStepperViewController {
 // MARK: Target actions
 extension MultiStepperViewController {
 	@IBAction func didPressStepButton(_ sender: NSButton) {
-		let step = Step(rawValue: self.popUpButton.indexOfSelectedItem)!
-		let count = self.textField.integerValue
-		self.handler?(.step(step, count))
+		if let handler = self.handler,
+		   let step = Step(rawValue: self.popUpButton.indexOfSelectedItem) {
+			let count = self.textField.integerValue
+			handler(step, count)
+			
+			self.defaults.debugStep = step
+			self.defaults.debugStepCount = count
+		}
 	}
 	
 	@IBAction func didPressDoneButton(_ sender: NSButton) {
-		self.handler?(.done)
+		if let window = self.view.window,
+		   let index = window.titlebarAccessoryViewControllers.firstIndex(of: self) {
+			window.removeTitlebarAccessoryViewController(at: index)
+		}
 	}
 }
 

--- a/RayRacer/RayRacerDelegate.swift
+++ b/RayRacer/RayRacerDelegate.swift
@@ -271,6 +271,7 @@ extension RayRacerDelegate {
 		}
 		
 		let viewController = ScreenViewController(
+			console: self.console,
 			commandQueue: self.commandQueue,
 			pipelineState: self.pipelineState)
 		
@@ -287,6 +288,11 @@ extension RayRacerDelegate {
 		
 		self.showWindow(of: windowController)
 		self.defaults.addOpenedFileURL(url)
+		
+		DispatchQueue.global(qos: .userInitiated)
+			.async() { [unowned self] in
+				self.console.resume()
+			}
 	}
 }
 

--- a/RayRacer/RayRacerDelegate.swift
+++ b/RayRacer/RayRacerDelegate.swift
@@ -288,11 +288,6 @@ extension RayRacerDelegate {
 		
 		self.showWindow(of: windowController)
 		self.defaults.addOpenedFileURL(url)
-		
-		DispatchQueue.global(qos: .userInitiated)
-			.async() { [unowned self] in
-				self.console.resume()
-			}
 	}
 }
 

--- a/RayRacer/Screen/ScreenViewController.swift
+++ b/RayRacer/Screen/ScreenViewController.swift
@@ -89,10 +89,9 @@ extension ScreenViewController: MTKViewDelegate {
 	}
 	
 	func draw(in view: MTKView) {
-		// skip frame when console has been suspended by debugger
+		// skip frame when console has been suspended by another component
 		// or has not yet produced field data
-		guard self.screenDataReady,
-			  case .suspended(code: 0) = self.console.state else {
+		guard self.screenDataReady else {
 			return
 		}
 		

--- a/RayRacer/Screen/ScreenViewController.swift
+++ b/RayRacer/Screen/ScreenViewController.swift
@@ -12,7 +12,7 @@ import RayRacerKit
 class ScreenViewController: NSViewController {
 	private let console: Atari2600
 	private var screenData: Array<UInt8>
-	private var screenDataReady = false
+	private var screenDataReady: Bool
 	private var screenIndex = 0
 	
 	private let commandQueue: MTLCommandQueue
@@ -31,6 +31,7 @@ class ScreenViewController: NSViewController {
 	init(console: Atari2600, commandQueue: MTLCommandQueue, pipelineState: MTLRenderPipelineState) {
 		self.console = console
 		self.screenData = Array<UInt8>(repeating: 0, count: self.screenSize.count)
+		self.screenDataReady = true
 		
 		let device = commandQueue.device
 		guard let screenBuffer = device.makeBuffer(bytesNoCopy: &self.screenData, length: self.screenData.count),
@@ -76,18 +77,6 @@ extension ScreenViewController {
 			multiplier: 4.0/3.0))
 		
 		self.view = view
-	}
-	
-	override func viewDidAppear() {
-		super.viewDidAppear()
-		
-		// mark screen data being ready and suspend console with default
-		// suspension code, which will be resumed when display link triggers
-		// rendering the first field
-		if self.console.state == .off {
-			self.console.suspend()
-			self.screenDataReady = true
-		}
 	}
 }
 

--- a/RayRacerKit/Console.swift
+++ b/RayRacerKit/Console.swift
@@ -17,17 +17,12 @@ public class Atari2600: ObservableObject {
 	public var switches: Switches = .random()
 	public var joystic = Joystick()
 	
+	private(set) public var paused = true
+	
 	public init() {
 		self.cpu = MOS6507(bus: self)
 		self.riot = MOS6532(ports: (self.joystic, self))
 		self.tia = TIA()
-	}
-	
-	// Resets internal state.
-	public func reset() {
-		self.cpu.reset()
-		self.riot.reset()
-		self.tia.reset()
 	}
 	
 	public func setSwitch(_ switch: Switches, on: Bool) {
@@ -40,7 +35,30 @@ public class Atari2600: ObservableObject {
 	
 	public func insertCartridge(_ data: Data) {
 		self.cartridge = data
-		self.reset()
+	}
+	
+	/// Pauses program execution when it is being executed.
+	public func pause() {
+		self.paused = true
+	}
+	
+	/// Resumes program execution when it is paused.
+	public func resume() {
+		guard self.paused else {
+			return
+		}
+		
+		self.paused = false
+		while self.paused == false {
+			self.advanceCycle()
+		}
+	}
+	
+	/// Resets internal state.
+	public func reset() {
+		self.cpu.reset()
+		self.riot.reset()
+		self.tia.reset()
 	}
 }
 

--- a/RayRacerKit/Console.swift
+++ b/RayRacerKit/Console.swift
@@ -65,7 +65,16 @@ public class Atari2600: ObservableObject {
 	
 	/// Suspends console emulation with the specified optional suspension code.
 	public func suspend(code: Int = 0) {
-		self.state = .suspended(code)
+		switch self.state {
+		case .suspended(let currentCode):
+			// when emulation is currently suspended, overwrite suspension
+			// code only when it is higher than the current one
+			if code > currentCode {
+				self.state = .suspended(code)
+			}
+		default:
+			self.state = .suspended(code)
+		}
 	}
 	
 	/// Advances TIA clock by 3 units and RIOT and CPU clock by 1, unless CPU is halted by the TIA.

--- a/RayRacerKit/TIA.swift
+++ b/RayRacerKit/TIA.swift
@@ -230,6 +230,7 @@ extension TIA: Addressable {
 		case 0x00:
 			// MARK: VSYNC
 			self.verticalSync = data[1]
+			self.screenClock = 0
 		case 0x01:
 			// MARK: VBLANK
 			self.verticalBlank = data[1]


### PR DESCRIPTION
This update changes emulation to be driven by MTKView (CVDisplayLink) in order to display emulated TV fields at a constant frame rate. To achieve it, this update changes console emulation approach to suspend/resume emulation for each rendered frame instead of an unhinged run-loop.