### PR TITLE
Add support for double- and quad-sized player graphics.

### DIFF
--- a/RayRacer.xcodeproj/project.pbxproj
+++ b/RayRacer.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		950641DF2A39C4E700938403 /* AssemblyAddressCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950641DE2A39C4E700938403 /* AssemblyAddressCellView.swift */; };
 		950641E32A39CDAB00938403 /* BreakpointToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950641E22A39CDAB00938403 /* BreakpointToggle.swift */; };
 		950A64A12C4BCD3C007D4362 /* Addressable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950A64A02C4BCD3C007D4362 /* Addressable.swift */; };
+		9512A7F42D0F0A5E009EB065 /* RayRacerKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 953D92A72A1AEB7400EC52AC /* RayRacerKit.framework */; };
+		9512A7F52D0F0A5E009EB065 /* RayRacerKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 953D92A72A1AEB7400EC52AC /* RayRacerKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9517A47B2A486020002D1F20 /* UserDefaults+Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9517A47A2A486020002D1F20 /* UserDefaults+Preferences.swift */; };
 		951CC4FE2A58723300537CD1 /* FormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951CC4FD2A58723300537CD1 /* FormView.swift */; };
 		9523FDAB2C8D81DB0094A597 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9523FDAA2C8D81DB0094A597 /* PerformanceTests.swift */; };
@@ -57,6 +59,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		9512A7F62D0F0A5E009EB065 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 951E2F7B2A18B11900E6902F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 953D92A62A1AEB7400EC52AC;
+			remoteInfo = RayRacerKit;
+		};
 		9523FDAD2C8D81DB0094A597 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 951E2F7B2A18B11900E6902F /* Project object */;
@@ -79,6 +88,20 @@
 			remoteInfo = RayRacerKit;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9512A7F82D0F0A5E009EB065 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9512A7F52D0F0A5E009EB065 /* RayRacerKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		9502E5962A423296007A32DA /* MOS6507+Assembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MOS6507+Assembly.swift"; sourceTree = "<group>"; };
@@ -160,6 +183,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9512A7F42D0F0A5E009EB065 /* RayRacerKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -354,11 +378,13 @@
 				954A18602A1AEE5800EBC582 /* Sources */,
 				954A18612A1AEE5800EBC582 /* Frameworks */,
 				954A18622A1AEE5800EBC582 /* Resources */,
+				9512A7F82D0F0A5E009EB065 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				95A2D0062C512C7600440622 /* PBXTargetDependency */,
+				9512A7F72D0F0A5E009EB065 /* PBXTargetDependency */,
 			);
 			name = RayRacer;
 			productName = Atari2600;
@@ -542,6 +568,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9512A7F72D0F0A5E009EB065 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 953D92A62A1AEB7400EC52AC /* RayRacerKit */;
+			targetProxy = 9512A7F62D0F0A5E009EB065 /* PBXContainerItemProxy */;
+		};
 		9523FDAE2C8D81DB0094A597 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 953D92A62A1AEB7400EC52AC /* RayRacerKit */;
@@ -832,7 +863,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 0.1;
+				MARKETING_VERSION = 0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsyba.RayRacer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -865,7 +896,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 0.1;
+				MARKETING_VERSION = 0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tsyba.RayRacer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/RayRacer/Debugger/DebugColorTableCellView.swift
+++ b/RayRacer/Debugger/DebugColorTableCellView.swift
@@ -35,19 +35,21 @@ class DebugColorTableCellView: NSTableCellView {
 // MARK: -
 // MARK: Convenience functionality
 private extension NSColor {
-	convenience init(ntscColor color: Int) {
-		let color1 = withUnsafePointer(to: ntsc_palette) {
-			let pointer = $0.pointer(to: \.0)
-			let index = color / 2 * 3
-			
-			return pointer![index]
+	static let ntscPalette: [simd_float3] = {
+		return withUnsafePointer(to: ntsc_palette) {
+			let item = $0.pointer(to: \.0)
+			return (0..<128)
+				.compactMap({ item?[$0] })
+				.map({ simd_float3($0) / 255.0 })
 		}
-		
-		let color2 = simd_float3(color1) / 255.0
+	}()
+	
+	convenience init(ntscColor color: Int) {
+		let components = Self.ntscPalette[color / 2]
 		self.init(
-			red: CGFloat(color2.x),
-			green: CGFloat(color2.y),
-			blue: CGFloat(color2.z),
+			red: CGFloat(components.x),
+			green: CGFloat(components.y),
+			blue: CGFloat(components.z),
 			alpha: 1.0)
 	}
 }

--- a/RayRacer/Debugger/SystemStateViewController.swift
+++ b/RayRacer/Debugger/SystemStateViewController.swift
@@ -205,7 +205,7 @@ extension SystemStateViewController: NSOutlineViewDelegate {
 		
 		switch item {
 		case .value:
-			view?.stringValue = (item.rawValue, "\(riot.timer.clock)")
+			view?.stringValue = (item.rawValue, "\(riot.timer.0)")
 		case .interval:
 			view?.stringValue = (item.rawValue, "\(riot.timer.interval)")
 		}

--- a/RayRacerKit/Console+ControllerPorts.swift
+++ b/RayRacerKit/Console+ControllerPorts.swift
@@ -16,7 +16,7 @@ extension Atari2600: MOS6532.Peripheral {
 		return (data1 & 0x0f) | ((data0 << 4) & 0xf0)
 	}
 	
-	public func write(_ data: Int) {
+	public func write(_ data: Int, mask: Int) {
 		// TODO:
 	}
 }

--- a/RayRacerKit/Console+Switches.swift
+++ b/RayRacerKit/Console+Switches.swift
@@ -28,10 +28,12 @@ extension Atari2600.Switches: MOS6532.Peripheral {
 		return self.rawValue ^ 0x03
 	}
 	
-	public mutating func write(_ data: Int) {
+	public mutating func write(_ data: Int, mask: Int) {
 		// switches are supposed to be read-only, but can be written to
 		// nonetheless; writing sets the 3 unused bits
-		self.rawValue &= ~0x34
-		self.rawValue |= data & 0x34
+		let mask = mask & 0x34
+		
+		self.rawValue &= ~mask
+		self.rawValue |= data & mask
 	}
 }

--- a/RayRacerKit/MOS6507.swift
+++ b/RayRacerKit/MOS6507.swift
@@ -806,7 +806,7 @@ private extension MOS6507 {
 				low -= 0xa
 			}
 			
-			var result = high * 0x10 + low
+			result = high * 0x10 + low
 			if result > 0x99 {
 				self.status[.carry] = true
 				result -= 0xa0

--- a/RayRacerKit/MOS6507.swift
+++ b/RayRacerKit/MOS6507.swift
@@ -810,14 +810,18 @@ private extension MOS6507 {
 			
 			result = high * 0x10 + low
 			if result > 0x99 {
-				self.status[.carry] = true
 				result -= 0xa0
+				self.status[.carry] = true
+			} else {
+				self.status[.carry] = false
 			}
 		} else {
 			result = self.accumulator + operand + carry
 			if result > 0xff {
-				self.status[.carry] = true
 				result -= 0x100
+				self.status[.carry] = true
+			} else {
+				self.status[.carry] = false
 			}
 		}
 		
@@ -843,14 +847,18 @@ private extension MOS6507 {
 			
 			result = high * 0x10 + low
 			if result < 0x0 {
-				self.status[.carry] = true
 				result += 0xa0
+				self.status[.carry] = false
+			} else {
+				self.status[.carry] = true
 			}
 		} else {
 			result = self.accumulator - operand - borrow
 			if result < 0x0 {
-				self.status[.carry] = true
 				result += 0x100
+				self.status[.carry] = false
+			} else {
+				self.status[.carry] = true
 			}
 		}
 		
@@ -858,7 +866,6 @@ private extension MOS6507 {
 		
 		self.accumulator = result
 		self.status[.overflow] = overflow[7]
-		self.status[.carry] = result >= 0x0
 	}
 	
 	func bitTestAccumulator(withValueAt address: Int) {

--- a/RayRacerKit/MOS6532.swift
+++ b/RayRacerKit/MOS6532.swift
@@ -19,7 +19,7 @@ public class MOS6532 {
 		self.peripherals.a = NoPeripheral()
 		self.peripherals.b = NoPeripheral()
 		
-		self.memory = Data(randomOfCount: 128)
+		self.memory = Data(repeating: 0x0, count: 128)
 		self.timer = .random()
 	}
 	
@@ -27,7 +27,7 @@ public class MOS6532 {
 	func reset() {
 		// both ports are set as input on reset
 		self.dataDirection = (0x0, 0x0)
-		self.memory = Data(randomOfCount: 128)
+		self.memory = Data(repeating: 0x0, count: 128)
 		self.timer = .random()
 	}
 	
@@ -40,7 +40,7 @@ public class MOS6532 {
 extension MOS6532 {
 	public protocol Peripheral {
 		func read() -> Int
-		mutating func write(_ data: Int)
+		mutating func write(_ data: Int, mask: Int)
 	}
 }
 
@@ -49,7 +49,7 @@ private struct NoPeripheral: MOS6532.Peripheral {
 		return .random(in: 0x00...0xff)
 	}
 	
-	mutating func write(_ data: Int) {
+	mutating func write(_ data: Int, mask: Int) {
 	}
 }
 
@@ -138,30 +138,22 @@ extension MOS6532: Addressable {
 			// MARK: Data A
 		case 0x00, 0x08, 0x10, 0x18:
 			self.data.a = data
-			// write data to peripheral for output pins
-			let output = data & self.dataDirection.a
-			self.peripherals.a.write(output)
+			self.peripherals.a.write(self.data.a, mask: self.dataDirection.a)
 			
 			// MARK: Data direction A
 		case 0x01, 0x09, 0x11, 0x19:
 			self.dataDirection.a = data
-			// write data to peripheral for output pins
-			let output = self.data.a & data
-			self.peripherals.a.write(output)
+			self.peripherals.a.write(self.data.a, mask: self.dataDirection.a)
 			
 			// MARK: Data B
 		case 0x02, 0x0a, 0x12, 0x1a:
 			self.data.b = data
-			// write data to peripheral for output pins
-			let output = data & self.dataDirection.b
-			self.peripherals.b.write(output)
+			self.peripherals.a.write(self.data.b, mask: self.dataDirection.b)
 			
 			// MARK: Data direction B
 		case 0x03, 0xb, 0x13, 0x1b:
 			self.dataDirection.b = data
-			// write data to peripheral for output pins
-			let output = self.data.b & data
-			self.peripherals.b.write(output)
+			self.peripherals.b.write(self.data.b, mask: self.dataDirection.b)
 			
 		case 0x14:
 			// MARK: TIM1T

--- a/RayRacerKit/TIA+Player.swift
+++ b/RayRacerKit/TIA+Player.swift
@@ -27,10 +27,18 @@ extension TIA.Player: TIA.Drawable {
 		0x011, // ●○○●○○○○○○
 		0x015, // ●○●○●○○○○○
 		0x101, // ●○○○○○○○●○
-		0x001, // ●●○○○○○○○○
+		0x003, // ●●○○○○○○○○
 		0x111, // ●○○○●○○○●○
-		0x001  // ●●●●○○○○○○
+		0x00f  // ●●●●○○○○○○
 	]
+	
+	private var scale: Int {
+		switch self.copies {
+		case 5: return 2
+		case 7: return 4
+		default: return 1
+		}
+	}
 	
 	public func draws(at position: Int) -> Bool {
 		let counter = position - self.position
@@ -47,8 +55,10 @@ extension TIA.Player: TIA.Drawable {
 		? self.graphics.1
 		: self.graphics.0
 		
+		let bit = (counter % 8) / self.scale
+		
 		return self.reflected
-		? graphics[counter % 8]
-		: graphics[7 - counter % 8]
+		? graphics[bit]
+		: graphics[7 - bit]
 	}
 }

--- a/RayRacerKit/TIA+Player.swift
+++ b/RayRacerKit/TIA+Player.swift
@@ -55,7 +55,7 @@ extension TIA.Player: TIA.Drawable {
 		? self.graphics.1
 		: self.graphics.0
 		
-		let bit = (counter % 8) / self.scale
+		let bit = (counter / self.scale) % 8
 		
 		return self.reflected
 		? graphics[bit]

--- a/RayRacerKit/TIA.swift
+++ b/RayRacerKit/TIA.swift
@@ -257,7 +257,9 @@ extension TIA: Addressable {
 		case 0x00:
 			// MARK: VSYNC
 			self.verticalSync = data[1]
-			self.screenClock = 0
+			if !self.verticalSync {
+				self.screenClock = 0
+			}
 		case 0x01:
 			// MARK: VBLANK
 			self.vblank = data

--- a/RayRacerKit/TIA.swift
+++ b/RayRacerKit/TIA.swift
@@ -78,18 +78,6 @@ public class TIA {
 	
 	/// Advances color clock by 1 unit.
 	public func advanceClock() {
-//		var input = self.peripheral.read()
-//		if self.vblank[7] {
-//			// when dumped ports disabled, ground
-//			input &= 0xf0
-//		}
-//		if self.vblank[6] {
-//			// when latched ports disabled, latch low
-//			input &= self.input | 0x0f
-//		}
-//		self.input = input
-		
-		
 		if self.verticalBlank || self.horizontalBlank {
 			self.output?.write(color: 0)
 		} else {
@@ -138,8 +126,8 @@ extension TIA {
 	private func graphicsState(at point: Int) -> Int {
 		var state = 0
 		state[0] = self.players.0.draws(at: point)
-		state[1] = self.players.1.draws(at: point)
-		state[2] = self.missiles.0.draws(at: point)
+		state[1] = self.missiles.0.draws(at: point)
+		state[2] = self.players.1.draws(at: point)
 		state[3] = self.missiles.1.draws(at: point)
 		state[4] = self.ball.draws(at: point)
 		state[5] = self.playfield.draws(at: point)
@@ -181,28 +169,28 @@ extension TIA {
 		.map() {
 			var collisions = 0
 			// cxm0p
-			collisions[0] = $0[2] && $0[0]
-			collisions[1] = $0[2] && $0[1]
+			collisions[0] = $0[1] && $0[0]
+			collisions[1] = $0[1] && $0[2]
 			// cxm1p
-			collisions[2] = $0[3] && $0[1]
+			collisions[2] = $0[3] && $0[2]
 			collisions[3] = $0[3] && $0[0]
 			// cxp0fb
 			collisions[4] = $0[0] && $0[4]
 			collisions[5] = $0[0] && $0[5]
 			// cxp1fb
-			collisions[6] = $0[1] && $0[4]
-			collisions[7] = $0[1] && $0[5]
+			collisions[6] = $0[2] && $0[4]
+			collisions[7] = $0[2] && $0[5]
 			// cxm0fb
-			collisions[8] = $0[2] && $0[4]
-			collisions[9] = $0[2] && $0[5]
+			collisions[8] = $0[1] && $0[4]
+			collisions[9] = $0[1] && $0[5]
 			// cxm1fb
 			collisions[10] = $0[3] && $0[4]
 			collisions[11] = $0[3] && $0[5]
 			// cxblpf
 			collisions[12] = $0[4] && $0[5]
 			// cxppmm
-			collisions[13] = $0[2] && $0[3]
-			collisions[14] = $0[0] && $0[1]
+			collisions[13] = $0[1] && $0[3]
+			collisions[14] = $0[0] && $0[2]
 			
 			return collisions
 		}

--- a/RayRacerKit/TIA.swift
+++ b/RayRacerKit/TIA.swift
@@ -276,11 +276,11 @@ extension TIA: Addressable {
 			self.colorClock = 0
 		case 0x04:
 			// MARK: NUSIZ0
-			self.players.0.copies = data & 0x3
+			self.players.0.copies = data & 0x7
 			self.missiles.0.size = 1 << ((data >> 4) & 0x3)
 		case 0x05:
 			// MARK: NUSIZ1
-			self.players.1.copies = data & 0x3
+			self.players.1.copies = data & 0x7
 			self.missiles.1.size = 1 << ((data >> 4) & 0x3)
 		case 0x06:
 			// MARK: COLUP0

--- a/RayRacerKitTests/MOS6532Tests.swift
+++ b/RayRacerKitTests/MOS6532Tests.swift
@@ -116,7 +116,7 @@ private class TestPeripheral: MOS6532.Peripheral {
 		return data
 	}
 	
-	func write(_ data: Int) {
+	func write(_ data: Int, mask: Int) {
 		self.data = data
 	}
 }

--- a/Readme.md
+++ b/Readme.md
@@ -7,9 +7,6 @@ Ray Racer is under development and offers only partial emulation at present.
 
 It does not emulate
 
-* double- and quad-sized player graphics
-* ~~movable object collisions~~
-* ~~console switches~~
 * any controller other than 1 button joystick
 * audio
 * cartridges over 4KB with bank-switching


### PR DESCRIPTION
This update adds emulation for double- and quad-sized player objects.

Additionally, this update
- fixes incorrect emulation of peripheral interface in MOS6532
- fixes a bug where incorrect color was chosen for player 1 object